### PR TITLE
Fixes which prevent configBase (default code specified config values)…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out/
 node_modules/
+.idea/

--- a/src/lex-web-ui-loader/js/defaults/lex-web-ui.js
+++ b/src/lex-web-ui-loader/js/defaults/lex-web-ui.js
@@ -27,7 +27,6 @@ export const configBase = {
   iframe: {
     iframeOrigin: '',
     iframeSrcPath: '',
-    shouldLoadIframeMinimized: true,
   },
 };
 

--- a/src/lex-web-ui-loader/js/index.js
+++ b/src/lex-web-ui-loader/js/index.js
@@ -156,13 +156,16 @@ export class IframeLoader extends Loader {
   }
 
   load(configParam = {}) {
-    this.config.iframe = this.config.iframe || {};
-    this.config.iframe.iframeSrcPath = this.mergeSrcPath(configParam);
-
     return super.load(configParam)
       .then(() => {
         // assign API to this object to make calls more succint
         this.api = this.compLoader.api;
+        // make sure iframe and iframeSrcPath are set to values if not
+        // configured by standard mechanisms. At this point, default
+        // values from ./defaults/loader.js will be used.
+        this.config.iframe = this.config.iframe || {};
+        this.config.iframe.iframeSrcPath = this.config.iframe.iframeSrcPath ||
+          this.mergeSrcPath(configParam);
       });
   }
 

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -61,6 +61,9 @@ export class IframeComponentLoader {
       this.config.iframe.iframeOrigin =
         this.config.parentOrigin || window.location.origin;
     }
+    if (iframeConfig.shouldLoadIframeMinimized === undefined) {
+      this.config.iframe.shouldLoadIframeMinimized = true;
+    }
     // assign parentOrigin if not found in config
     if (!(this.config.parentOrigin)) {
       this.config.parentOrigin =
@@ -102,6 +105,11 @@ export class IframeComponentLoader {
       console.error('missing parentOrigin config field');
       return false;
     }
+    if (!('shouldLoadIframeMinimized' in iframeConfig)) {
+      console.error('missing shouldLoadIframeMinimized config field');
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
… from overriding those specified in the json configuration file loaded via the deployed website. Remove "shouldLoadIframeMinizmied" from configBase. Validate existence of shouldLoadIframeMinimized in configuration and set to default to "true" if not configured. Re-ordered when a a default "iframeSrcPath" is merged to configuration so as to not override that specified in the web based json configuration file.