### PR TITLE
Added a response card title exists check before doing title trim

### DIFF
--- a/lex-web-ui/src/components/ResponseCard.vue
+++ b/lex-web-ui/src/components/ResponseCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card>
     <div v-if=shouldDisplayResponseCardTitle>
-      <v-card-title v-if="responseCard.title.trim()" primary-title class="red lighten-5">
+      <v-card-title v-if="responseCard.title && responseCard.title.trim()" primary-title class="red lighten-5">
         <span class="headline">{{responseCard.title}}</span>
       </v-card-title>
     </div>


### PR DESCRIPTION
Added a title exists or not before doing an trim on the title string. There is possibility that title can be null and response card won't render in that particular case because doing trim on null.

*Issue #185 :*
This is not an exact issue, but while checking on above issue caught my eyes on it.

*Description of changes:*
There is possibility that response card title can be **null** and the response card won't render in that particular case because doing trim on **null**.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
