### PR TITLE
refreshing main window on link clicked with a matching domain

### DIFF
--- a/config/base.env.js
+++ b/config/base.env.js
@@ -27,6 +27,7 @@ module.exports = {
     negativeFeedbackIntent: process.env.NEGATIVE_INTENT,
     helpIntent: process.env.HELP_INTENT,
     minButtonToolTipContent: process.env.MIN_BUTTON_TOOLTIP_CONTENT,
+    refreshWindowOnLinkClick: process.env.DOMAIN_MATCH_ON_LINK_CLICK,
     enableLogin: (process.env.ENABLE_LOGIN === undefined) ? undefined : (process.env.ENABLE_LOGIN === 'true') ? true : false,
     forceLogin: (process.env.FORCE_LOGIN === undefined) ? undefined : (process.env.FORCE_LOGIN === 'true') ? true : false,
     AllowSuperDangerousHTMLInMessage: (process.env.ENABLE_MARKDOWN_SUPPORT === undefined) ? undefined : (process.env.ENABLE_MARKDOWN_SUPPORT === 'true') ? true : false,

--- a/lex-web-ui/README.md
+++ b/lex-web-ui/README.md
@@ -432,11 +432,11 @@ or HTML mechanisms.
 #### Markdown with links
 Markdown `<a href>` links open in a new window by default. If you want links of a specific domain to
 refresh the current window rather than launch a new one you can add the domain to match in the config `ui.refreshWindowOnLinkClick`.
-Using a matching string allows you to set the value to; a domain name, a root domain or a subdomain.The value is required to contain a '.' i.e
+Using a matching string allows you to set the value to; a full domain name (including subdomain prefix) or a root domain (excluding subdomain prefix). i.e
 ```
-ui.refreshWindowOnLinkClick = "amazon." will refresh the window if links match this domain name irrespective of the top-level domain
-ui.refreshWindowOnLinkClick = "amazon.com" will refresh the window if links match this root domain
-ui.refreshWindowOnLinkClick = "aws.amazon.com" will only refresh the window if links match this subdomain
+ui.refreshWindowOnLinkClick = "" (default) all links will launch a new window
+ui.refreshWindowOnLinkClick = "amazon.com" current window will refresh if any links match this root domain
+ui.refreshWindowOnLinkClick = "www.amazon.com" or "aws.amazon.com" current window will only refresh if links match the subdomain
 ```
 
 ## Controlling the bot's input focus

--- a/lex-web-ui/README.md
+++ b/lex-web-ui/README.md
@@ -426,8 +426,18 @@ methods. Highest priority first.
 2. HTML provided via appContext.altMessages
 3. Markdown provided via appContext.altMessages 
 
-The standard message returned from Lex will not be shown if any content exists from any of Markdown
-or HTML mechanisms. 
+The standard message returned from Lex will not be shown if any content exists from any of Markdown 
+or HTML mechanisms.
+
+#### Markdown with links
+Markdown `<a href>` links open in a new window by default. If you want links of a specific domain to
+refresh the current window rather than launch a new one you can add the domain to match in the config `ui.refreshWindowOnLinkClick`.
+Using a matching string allows you to set the value to a doamin name, a root domain or a subdomain. i.e
+```
+ui.refreshWindowOnLinkClick = "amazon." will refresh the window if links match this domain name irrespective of the top-level domain
+ui.refreshWindowOnLinkClick = "amazon.com" will refresh the window if links match this root domain
+ui.refreshWindowOnLinkClick = "aws.amazon.com" will only refresh the window if links match this subdomain
+```
 
 ## Controlling the bot's input focus
 The Lex Web UI allows the user to input text and hit CR to send the request to the bot. Alternatively the user

--- a/lex-web-ui/README.md
+++ b/lex-web-ui/README.md
@@ -432,7 +432,7 @@ or HTML mechanisms.
 #### Markdown with links
 Markdown `<a href>` links open in a new window by default. If you want links of a specific domain to
 refresh the current window rather than launch a new one you can add the domain to match in the config `ui.refreshWindowOnLinkClick`.
-Using a matching string allows you to set the value to a doamin name, a root domain or a subdomain. i.e
+Using a matching string allows you to set the value to; a domain name, a root domain or a subdomain.The value is required to contain a '.' i.e
 ```
 ui.refreshWindowOnLinkClick = "amazon." will refresh the window if links match this domain name irrespective of the top-level domain
 ui.refreshWindowOnLinkClick = "amazon.com" will refresh the window if links match this root domain

--- a/lex-web-ui/package-lock.json
+++ b/lex-web-ui/package-lock.json
@@ -1513,6 +1513,12 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -1609,6 +1615,14 @@
         "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        }
       }
     },
     "babel-runtime": {
@@ -1619,6 +1633,14 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        }
       }
     },
     "babel-template": {
@@ -2599,10 +2621,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-      "dev": true
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3736,11 +3757,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.298.tgz",
       "integrity": "sha512-IcgwlR5x4qtsVr1X+GDnbDEp0bAAqRA9EHP+bvIn3g5KF59Eiqjm59p27tg8b4YmgmpjfKWgec3trDRTWiVJgg==",
       "dev": true
-    },
-    "element-closest": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-3.0.2.tgz",
-      "integrity": "sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g=="
     },
     "elliptic": {
       "version": "6.5.3",

--- a/lex-web-ui/package-lock.json
+++ b/lex-web-ui/package-lock.json
@@ -3737,6 +3737,11 @@
       "integrity": "sha512-IcgwlR5x4qtsVr1X+GDnbDEp0bAAqRA9EHP+bvIn3g5KF59Eiqjm59p27tg8b4YmgmpjfKWgec3trDRTWiVJgg==",
       "dev": true
     },
+    "element-closest": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-3.0.2.tgz",
+      "integrity": "sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g=="
+    },
     "elliptic": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",

--- a/lex-web-ui/package.json
+++ b/lex-web-ui/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.671.0",
-    "element-closest": "^3.0.2",
+    "core-js": "^3.6.5",
     "jsonwebtoken": "^8.3.0",
     "marked": "^0.7.0",
     "material-design-icons": "^3.0.1",

--- a/lex-web-ui/package.json
+++ b/lex-web-ui/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.671.0",
+    "element-closest": "^3.0.2",
     "jsonwebtoken": "^8.3.0",
     "marked": "^0.7.0",
     "material-design-icons": "^3.0.1",

--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -224,7 +224,7 @@ export default {
     }
     this.onResize();
     window.addEventListener('resize', this.onResize, { passive: true });
-    const { refreshWindowOnLinkClick } = this.$store.state.config.ui
+    const { refreshWindowOnLinkClick } = this.$store.state.config.ui;
     if (refreshWindowOnLinkClick && refreshWindowOnLinkClick.includes('.')) {
       window.addEventListener('click', this.onLinkClickHandler);
     }

--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -240,13 +240,10 @@ export default {
       if (e.target.localName === 'a') {
         const { href } = e.target;
         const { refreshWindowOnLinkClick } = this.$store.state.config.ui;
-
         if (!href) {
           return true;
         }
-
         const url = new URL(href);
-
         if (
           (url.protocol === 'http:' || url.protocol === 'https:') &&
           (
@@ -259,7 +256,7 @@ export default {
           e.preventDefault(); // stop the event propagating any further
           this.$store.dispatch(
             'sendMessageToParentWindow',
-            { event: 'refreshWindowWithLink', payload: href },
+            { event: 'refreshWindowWithLink', payload: url.href },
           );
           return false;
         }

--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -61,7 +61,7 @@ License for the specific language governing permissions and limitations under th
 */
 
 /* eslint no-console: ["error", { allow: ["warn", "error", "info"] }] */
-
+import 'element-closest/browser';
 import MinButton from '@/components/MinButton';
 import ToolbarContainer from '@/components/ToolbarContainer';
 import MessageList from '@/components/MessageList';
@@ -224,11 +224,32 @@ export default {
     }
     this.onResize();
     window.addEventListener('resize', this.onResize, { passive: true });
+    const { refreshWindowOnLinkClick } = this.$store.state.config.ui
+    if (refreshWindowOnLinkClick && refreshWindowOnLinkClick.includes('.')) {
+      window.addEventListener('click', this.onLinkClickHandler);
+    }
   },
   methods: {
     onResize() {
       const { innerWidth } = window;
       this.setToolbarHeigthClassSuffix(innerWidth);
+    },
+    onLinkClickHandler(e) {
+      // listens out for <a href> Link clicks and if they match the config domain
+      if (e.target.localName === 'a') {
+        const origin = e.target.closest('a');
+        const { href } = origin;
+        // let mailto: or tel: links and other domains pass through
+        if (href.includes('http') && href.includes(this.$store.state.config.ui.refreshWindowOnLinkClick)) {
+          e.preventDefault(); // stop the event propagating any further
+          this.$store.dispatch(
+            'sendMessageToParentWindow',
+            { event: 'refreshWindowWithLink', payload: href },
+          );
+          return false;
+        }
+      }
+      return true;
     },
     setToolbarHeigthClassSuffix(innerWidth) {
       // Vuetify toolbar changes height based on innerWidth

--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -61,7 +61,7 @@ License for the specific language governing permissions and limitations under th
 */
 
 /* eslint no-console: ["error", { allow: ["warn", "error", "info"] }] */
-import 'element-closest/browser';
+import 'core-js/features/url';
 import MinButton from '@/components/MinButton';
 import ToolbarContainer from '@/components/ToolbarContainer';
 import MessageList from '@/components/MessageList';
@@ -236,11 +236,26 @@ export default {
     },
     onLinkClickHandler(e) {
       // listens out for <a href> Link clicks and if they match the config domain
+      // let mailto: or tel: links and other domains pass through
       if (e.target.localName === 'a') {
-        const origin = e.target.closest('a');
-        const { href } = origin;
-        // let mailto: or tel: links and other domains pass through
-        if (href.includes('http') && href.includes(this.$store.state.config.ui.refreshWindowOnLinkClick)) {
+        const { href } = e.target;
+        const { refreshWindowOnLinkClick } = this.$store.state.config.ui;
+
+        if (!href) {
+          return true;
+        }
+
+        const url = new URL(href);
+
+        if (
+          (url.protocol === 'http:' || url.protocol === 'https:') &&
+          (
+            // full hostname match (i.e includes subdomain check)
+            url.hostname === refreshWindowOnLinkClick ||
+            // partial hostname match (root domain, i.e ignores subdomain check)
+            url.hostname.endsWith(`.${refreshWindowOnLinkClick}`)
+          )
+        ) {
           e.preventDefault(); // stop the event propagating any further
           this.$store.dispatch(
             'sendMessageToParentWindow',

--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -214,6 +214,10 @@ const configDefault = {
 
     // Optionally direct input focus to Bot text input as needed
     directFocusToBotInput: false,
+
+    // Optionally if an <a href> link is clicked with the same domain
+    // enforce refreshing main page rather than launching a new window
+    refreshWindowOnLinkClick: '',
   },
 
   /* Configuration to enable voice and to pass options to the recorder

--- a/src/config/lex-web-ui-loader-config.json
+++ b/src/config/lex-web-ui-loader-config.json
@@ -29,7 +29,8 @@
     "showDialogStateIcon": false,
     "backButton": false,
     "messageMenu": true,
-    "hideButtonMessageBubble": false
+    "hideButtonMessageBubble": false,
+    "refreshWindowOnLinkClick": ""
   },
   "polly": {
     "voiceId": "Salli"

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -16,6 +16,7 @@
 
 import { ConfigLoader } from './config-loader';
 import { logout, login, completeLogin, completeLogout, getAuth, refreshLogin, isTokenExpired, forceLogin } from './loginutil';
+import 'core-js/features/url';
 
 /**
  * Instantiates and mounts the chatbot component in an iframe
@@ -612,9 +613,14 @@ export class IframeComponentLoader {
       // refresh window from chatbot event
       refreshWindowWithLink(evt) {
         const href = evt.data.payload;
-        if (href && href.includes('http')) {
-          window.location = href;
+        if (!href) {
+          return;
         }
+        const url = new URL(href);
+        if (url.protocol === 'http:' || url.protocol === 'https:') {
+          window.location = url.href;
+        }
+
       },
 
       // sent to refresh auth tokens as requested by iframe

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -609,6 +609,14 @@ export class IframeComponentLoader {
         this.sendMessageToIframe({ event: 'confirmLogout' });
       },
 
+      // refresh window from chatbot event
+      refreshWindowWithLink(evt) {
+        const href = evt.data.payload;
+        if (href && href.includes('http')) {
+          window.location = href;
+        }
+      },
+
       // sent to refresh auth tokens as requested by iframe
       refreshAuthTokens(evt) {
         const refToken = localStorage.getItem('refreshtoken');

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -388,6 +388,8 @@ Resources:
                       Value: !Ref ShouldLoadIframeMinimized
                     - Name: SHOW_RESPONSE_CARD_TITLE
                       Value: !Ref ShowResponseCardTitle
+                    - Name: DOMAIN_MATCH_ON_LINK_CLICK
+                      Value: !Ref DomainMatchOnLinkClick
                     - Name: PARENT_ORIGIN
                       Value: !If
                         - NeedsParentOrigin


### PR DESCRIPTION
Markdown `<a href>` links open in a new window by default. If you want links of a specific domain to
refresh the current window rather than launch a new one you can add the domain to match in the config `ui.refreshWindowOnLinkClick`.
Using a matching string allows you to set the value to; a full domain name (including subdomain prefix) or a root domain (excluding subdomain prefix). i.e
```
ui.refreshWindowOnLinkClick = "" (default) all links will launch a new window
ui.refreshWindowOnLinkClick = "amazon.com" current window will refresh if any links match this root domain
ui.refreshWindowOnLinkClick = "www.amazon.com" or "aws.amazon.com" current window will only refresh if links match the subdomain
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
