### PR TITLE
Feature/aria live

### DIFF
--- a/lex-web-ui/src/components/MessageList.vue
+++ b/lex-web-ui/src/components/MessageList.vue
@@ -58,7 +58,6 @@ export default {
     setTimeout(() => {
       this.scrollDown();
     }, 1000);
-
     EventBus.$on('handleAriaLiveAtt', (eventType) => {
       const attAriaLive = document.createAttribute('aria-live');
       const chatMessageList = document.getElementsByClassName('message-list')[0];

--- a/lex-web-ui/src/components/MessageList.vue
+++ b/lex-web-ui/src/components/MessageList.vue
@@ -32,6 +32,7 @@ License for the specific language governing permissions and limitations under th
 */
 import Message from './Message';
 import MessageLoading from './MessageLoading';
+import EventBus from '../event-bus';
 
 export default {
   name: 'message-list',
@@ -57,6 +58,31 @@ export default {
     setTimeout(() => {
       this.scrollDown();
     }, 1000);
+
+    EventBus.$on('handleAriaLiveAtt', (eventType) => {
+      const attAriaLive = document.createAttribute('aria-live');
+      const chatMessageList = document.getElementsByClassName('message-list')[0];
+
+      if (eventType === 'messageSent') {
+        // Deactivation of aria-live (avoid double vocalization)
+        attAriaLive.value = 'off';
+        chatMessageList.setAttributeNode(attAriaLive);
+      } else if (eventType === 'messageReceived') {
+        if (chatMessageList.lastElementChild) {
+          const lastMessage = chatMessageList.lastElementChild.getElementsByClassName('message-bubble')[0];
+          // Put focus on the question (triggering of the vocalization)
+          // focus() needs to be wrapped in setTimeout for IE11
+          setTimeout(() => {
+            lastMessage.focus();
+          }, 10);
+        }
+        // Reactivation of aria-live
+        window.setTimeout(() => {
+          attAriaLive.value = 'polite';
+          chatMessageList.setAttributeNode(attAriaLive);
+        }, 0);
+      }
+    });
   },
   methods: {
     scrollDown() {

--- a/lex-web-ui/src/components/MessageList.vue
+++ b/lex-web-ui/src/components/MessageList.vue
@@ -58,28 +58,23 @@ export default {
     setTimeout(() => {
       this.scrollDown();
     }, 1000);
-    EventBus.$on('handleAriaLiveAtt', (eventType) => {
-      const attAriaLive = document.createAttribute('aria-live');
+    // Put focus on the answer (triggering vocalization for ScreenReaders)
+    EventBus.$on('messageEvent', (eventType) => {
       const chatMessageList = document.getElementsByClassName('message-list')[0];
-
-      if (eventType === 'messageSent') {
-        // Deactivation of aria-live (avoid double vocalization)
-        attAriaLive.value = 'off';
-        chatMessageList.setAttributeNode(attAriaLive);
-      } else if (eventType === 'messageReceived') {
-        if (chatMessageList.lastElementChild) {
-          const lastMessage = chatMessageList.lastElementChild.getElementsByClassName('message-bubble')[0];
-          // Put focus on the question (triggering of the vocalization)
+      const lastElChild = chatMessageList.lastElementChild;
+      if (eventType === 'messageReceived') {
+        if (lastElChild && lastElChild.classList.contains('message-bot')) {
+          const lastMessage = lastElChild.getElementsByClassName('message-bubble')[0];
           // focus() needs to be wrapped in setTimeout for IE11
-          setTimeout(() => {
+          const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+          if (isIE11) {
+            setTimeout(() => {
+              lastMessage.focus();
+            }, 10);
+          } else {
             lastMessage.focus();
-          }, 10);
+          }
         }
-        // Reactivation of aria-live
-        window.setTimeout(() => {
-          attAriaLive.value = 'polite';
-          chatMessageList.setAttributeNode(attAriaLive);
-        }, 0);
       }
     });
   },

--- a/lex-web-ui/src/components/ResponseCard.vue
+++ b/lex-web-ui/src/components/ResponseCard.vue
@@ -19,7 +19,7 @@
         v-for="(button) in responseCard.buttons"
         v-show="button.text && button.value"
         v-bind:key="button.id"
-        v-on:click.once.native="onButtonClick(button.value)"
+        v-on:click.once.native="(evt) => onButtonClick(evt, button.value)"
         v-bind:disabled="shouldDisableClickedResponseCardButtons"
         round
         default
@@ -76,8 +76,9 @@ export default {
     },
   },
   methods: {
-    onButtonClick(value) {
+    onButtonClick(evt, value) {
       this.hasButtonBeenClicked = true;
+      evt.target.blur();
 
       const messageType = this.$store.state.config.ui.hideButtonMessageBubble ? 'button' : 'human';
       const message = {

--- a/lex-web-ui/src/event-bus.js
+++ b/lex-web-ui/src/event-bus.js
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+
+const EventBus = new Vue();
+export default EventBus;

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -24,6 +24,7 @@ import silentOgg from '@/assets/silent.ogg';
 import silentMp3 from '@/assets/silent.mp3';
 
 import LexClient from '@/lib/lex/client';
+import EventBus from '../event-bus';
 
 const jwt = require('jsonwebtoken');
 
@@ -454,6 +455,7 @@ export default {
         'sendMessageToParentWindow',
         { event: 'messageSent' },
       );
+      EventBus.$emit('handleAriaLiveAtt', 'messageSent');
     }
     return context.dispatch('interruptSpeechConversation')
       .then(() => context.dispatch('pushMessage', message))
@@ -516,6 +518,7 @@ export default {
             'sendMessageToParentWindow',
             { event: 'messageReceived' },
           );
+          EventBus.$emit('handleAriaLiveAtt', 'messageReceived');
         }
         if (context.state.lex.dialogState === 'Fulfilled') {
           context.dispatch('reInitBot');

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -451,12 +451,12 @@ export default {
   postTextMessage(context, message) {
     if (context.state.isSFXOn) {
       context.dispatch('playSound', context.state.config.ui.messageSentSFX);
-      context.dispatch(
-        'sendMessageToParentWindow',
-        { event: 'messageSent' },
-      );
-      EventBus.$emit('handleAriaLiveAtt', 'messageSent');
     }
+    context.dispatch(
+      'sendMessageToParentWindow',
+      { event: 'messageSent' },
+    );
+    EventBus.$emit('messageEvent', 'messageSent');
     return context.dispatch('interruptSpeechConversation')
       .then(() => context.dispatch('pushMessage', message))
       .then(() => context.commit('pushUtterance', message.text))
@@ -514,12 +514,12 @@ export default {
       .then(() => {
         if (context.state.isSFXOn) {
           context.dispatch('playSound', context.state.config.ui.messageReceivedSFX);
-          context.dispatch(
-            'sendMessageToParentWindow',
-            { event: 'messageReceived' },
-          );
-          EventBus.$emit('handleAriaLiveAtt', 'messageReceived');
         }
+        context.dispatch(
+          'sendMessageToParentWindow',
+          { event: 'messageReceived' },
+        );
+        EventBus.$emit('messageEvent', 'messageReceived');
         if (context.state.lex.dialogState === 'Fulfilled') {
           context.dispatch('reInitBot');
         }


### PR DESCRIPTION
*Issue #, if available:*
Screen readers can vocalize messages twice 

*Description of changes:*
- Refactored Chatbot A11y to avoid using aria-live attribute due to different behaviour on Mac/PC. Now relying on setting focus to trigger ScreenReaders. This has the advantage of jumping straight from selecting an button option to the answer, bi-passing repeating your selection (while still retaining it if user shift-tabs back)
- New EventBus added so Vuex Store actions can communicate straight to Components

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.