### PR TITLE
fixed displaying of loading message

### DIFF
--- a/lex-web-ui/src/components/MessageList.vue
+++ b/lex-web-ui/src/components/MessageList.vue
@@ -52,6 +52,9 @@ export default {
     messages() {
       this.scrollDown();
     },
+    loading() {
+      this.scrollDown();
+    },
   },
   mounted() {
     setTimeout(() => {
@@ -61,9 +64,15 @@ export default {
   methods: {
     scrollDown() {
       return this.$nextTick(() => {
-        const lastMessageOffset = (this.$el.lastElementChild) ?
-          this.$el.lastElementChild.getBoundingClientRect().height : 0;
-        this.$el.scrollTop = this.$el.scrollHeight - lastMessageOffset;
+        if (this.$el.lastElementChild) {
+          const lastMessageHeight = this.$el.lastElementChild.getBoundingClientRect().height;
+          const isLastMessageLoading = this.$el.lastElementChild.classList.contains('messsge-loading');
+          if (isLastMessageLoading) {
+            this.$el.scrollTop = this.$el.scrollHeight;
+          } else {
+            this.$el.scrollTop = this.$el.scrollHeight - lastMessageHeight;
+          }
+        }
       });
     },
   },

--- a/lex-web-ui/src/components/MessageLoading.vue
+++ b/lex-web-ui/src/components/MessageLoading.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex message d-flex message-bot" aria-hidden="true">
+  <div class="flex message d-flex message-bot messsge-loading" aria-hidden="true">
     <!-- contains message and response card -->
     <v-layout column ma-2 class="message-layout">
 


### PR DESCRIPTION
Issue #, if available:
The loading message is sometimes not displayed as it's below the message list scroll line

Description of changes:
added watching the computed loading value
only offset the message list scroll position if the last message is not a loading message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
