### PR TITLE
Made CognitoAppUserPoolClientId and CognitoUserPoolId optional

### DIFF
--- a/templates/master-pipeline.yaml
+++ b/templates/master-pipeline.yaml
@@ -366,8 +366,16 @@ Resources:
                 CustomResourceCodeBucket: !Ref BootstrapBucket
                 CustomResourceCodeObject: !Sub "${BootstrapPrefix}/custom-resources-v0.18.0.zip"
                 CleanupBuckets: !Ref CleanupBuckets
-                CognitoAppUserPoolClientId: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolClientId
-                CognitoUserPoolId: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolId
+                CognitoAppUserPoolClientId: 
+                    !If
+                      - NeedsCognito
+                      - !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolClientId
+                      - ''
+                CognitoUserPoolId: 
+                    !If
+                      - NeedsCognito
+                      - !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolId
+                      - ''
                 WebAppConfNegativeFeedback: !Ref WebAppConfNegativeFeedback
                 WebAppConfPositiveFeedback: !Ref WebAppConfPositiveFeedback
                 WebAppConfHelp: !Ref WebAppConfHelp


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

When deploying via the Code Pipeline method, the CognitoUserPoolId and CognitoAppUserPoolClientId are required, even if you ask to use an existing Cognito Pool.

This change subs in empty strings in this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
