### PR TITLE
Check that initialText has a value, before pushing to message list

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -88,11 +88,13 @@ export default {
   },
   initMessageList(context) {
     context.commit('reloadMessages');
-    if (context.state.messages && context.state.messages.length === 0) {
-      context.commit('pushMessage', {
-        type: 'bot',
-        text: context.state.config.lex.initialText,
-      });
+    if (context.state.messages &&
+      context.state.messages.length === 0 &&
+      context.state.config.lex.initialText.length > 0) {
+        context.commit('pushMessage', {
+          type: 'bot',
+          text: context.state.config.lex.initialText,
+        });
     }
   },
   initLexClient(context, payload) {


### PR DESCRIPTION
*Issue #, if available:*
If no initialText is set in config then the UI can show a blank message - this is more obvious when an avatar image is set for the bot as all that is displayed is the avatar with no message

*Description of changes:*
Check that initialText has a value before pushing an initial message to the message list.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
