### PR TITLE
Error in LexruntimeV2 can't be instantiated due to config issues

### DIFF
--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -161,8 +161,17 @@ export default {
         // using credentials built from the identified poolId.
         //
         // The Cognito Identity Pool should be a resource in the identified region.
-        if (this.$store.state && this.$store.state.config
-          && this.$store.state.config.region && this.$store.state.config.cognito.poolId) {
+        if (this.$store.state && this.$store.state.config) {
+          const region = this.$store.state.config.region ? this.$store.state.config.region : this.$store.state.config.cognito.region;
+          if (!region) {
+            return Promise.reject(new Error('no region found in config or config.cognito'))
+          }
+          
+          const poolId = this.$store.state.config.cognito.poolId;
+          if (!poolId) {
+            return Promise.reject(new Error('no cognito.poolId found in config'))
+          }
+
           const AWSConfigConstructor = (window.AWS && window.AWS.Config) ?
             window.AWS.Config :
             AWSConfig;
@@ -175,25 +184,27 @@ export default {
           const LexRuntimeConstructor = (window.AWS && window.AWS.LexRuntime) ?
             window.AWS.LexRuntime :
             LexRuntime;
-
+            
           const LexRuntimeConstructorV2 = (window.AWS && window.AWS.LexRuntimeV2) ?
             window.AWS.LexRuntimeV2 :
             LexRuntimeV2;
-
+            
           const credentials = new CognitoConstructor(
-            { IdentityPoolId: this.$store.state.config.cognito.poolId },
-            { region: this.$store.state.config.region },
+            { IdentityPoolId: poolId },
+            { region: region },
           );
 
           const awsConfig = new AWSConfigConstructor({
-            region: this.$store.state.config.region,
+            region: region,
             credentials,
           });
 
           this.$lexWebUi.lexRuntimeClient = new LexRuntimeConstructor(awsConfig);
           this.$lexWebUi.lexRuntimeV2Client = new LexRuntimeConstructorV2(awsConfig);
           /* eslint-disable no-console */
-          console.log(`${JSON.stringify(this.$lexWebUi.lexRuntimeV2Client)}`);
+          console.log(`lexRuntimeV2Client : ${JSON.stringify(this.$lexWebUi.lexRuntimeV2Client)}`);
+        } else {
+          return Promise.reject(new Error('no config found'))
         }
 
         Promise.all([

--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -184,11 +184,11 @@ export default {
           const LexRuntimeConstructor = (window.AWS && window.AWS.LexRuntime) ?
             window.AWS.LexRuntime :
             LexRuntime;
-            
+
           const LexRuntimeConstructorV2 = (window.AWS && window.AWS.LexRuntimeV2) ?
             window.AWS.LexRuntimeV2 :
             LexRuntimeV2;
-            
+
           const credentials = new CognitoConstructor(
             { IdentityPoolId: poolId },
             { region: region },


### PR DESCRIPTION
*Issue #, if available:*
if LexruntimeV2 is expected but can't be instantiated due to config issues missing region or cognito.poolId then it fails silently

*Description of changes:*
if no config.region set, fall back to checking config.cognito.region
throw an error if LexruntimeV2 is unable to be instantiated. explaining if there's no region, poolId or config set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
