### PR TITLE
Fix: Use human friendly style for message date when saveHistory=true

### DIFF
--- a/lex-web-ui/src/store/mutations.js
+++ b/lex-web-ui/src/store/mutations.js
@@ -32,7 +32,12 @@ export default {
     const value = sessionStorage.getItem('store');
     if (value !== null) {
       const sessionStore = JSON.parse(value);
-      state.messages = sessionStore.messages;
+      // convert date string into Date object in messages
+      state.messages = sessionStore.messages.map(message => {
+        return Object.assign({}, message, {
+          date: new Date(message.date)
+        });
+      });
     }
   },
 


### PR DESCRIPTION
*Issue #, if available:* N/A. 

*Description of changes:* Dates displayed below messages have human friendly style, but don't after reloading with saveHistory=true. This PR let UI convert string date field in messages into Date object when reloading messages, by following the object scheme of new messages.

<img width="250" alt="Screen Shot 2021-10-11 at 7 59 18" src="https://user-images.githubusercontent.com/1989039/136720012-aa50b2ea-b34a-41d6-8773-60f1c79f8925.png">
<img width="250" alt="Screen Shot 2021-10-11 at 10 07 41" src="https://user-images.githubusercontent.com/1989039/136720015-cff50942-1e66-48b9-8502-b7653e57ed76.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
