### PR TITLE
Fix agent link in live chat

### DIFF
--- a/lex-web-ui/src/components/MessageText.vue
+++ b/lex-web-ui/src/components/MessageText.vue
@@ -70,7 +70,7 @@ export default {
       return out;
     },
     shouldRenderAsHtml() {
-      return (this.message.type === 'bot' && this.shouldConvertUrlToLinks);
+      return (['bot', 'agent'].includes(this.message.type) && this.shouldConvertUrlToLinks);
     },
     botMessageAsHtml() {
       // Security Note: Make sure that the content is escaped according


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* URL links sent from agents are now converted to link texts as in the case of bot.
<img width="1048" alt="Screen Shot 2021-10-11 at 10 36 04" src="https://user-images.githubusercontent.com/1989039/136721776-a74745bb-5c3e-4994-96b8-aa1983f6f229.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
