### PR TITLE
Parameterize live chat terms

### DIFF
--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -72,6 +72,8 @@ const configDefault = {
     // The default interval with which to display the waitingForAgentMessage. When set to 0
     // the timer is disabled.
     waitingForAgentMessageIntervalSeconds: 60,
+    // Terms to start live chat
+    liveChatTerms: 'live chat',
   },
   lex: {
     // Lex V2 fields

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -29,7 +29,6 @@ import LexClient from '@/lib/lex/client';
 
 const jwt = require('jsonwebtoken');
 const AWS = require('aws-sdk');
-const liveChatTerms = ['live chat'];
 
 // non-state variables that may be mutated outside of store
 // set via initializers at run time
@@ -479,6 +478,7 @@ export default {
         return Promise.resolve();
       })
       .then(() => {
+        const liveChatTerms = context.state.config.connect.liveChatTerms ? context.state.config.connect.liveChatTerms.split(',') : [];
         if (context.state.config.ui.enableLiveChat && liveChatTerms.find(el => el === message.text.toLowerCase())) {
           return context.dispatch('requestLiveChat');
         } else if (context.state.liveChat.status === liveChatStatus.REQUEST_USERNAME) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Define the parameter _liveChatTerms_ in the config, which was previously defined hard-coded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
