### PR TITLE
fix: dispacth sendInitialUtterance at reInitBot and resetHistory

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -215,6 +215,7 @@ export default {
           markdown: context.state.config.lex.initialText,
         },
       });
+      context.dispatch('sendInitialUtterance');
     }
     return Promise.resolve();
   },
@@ -1127,6 +1128,7 @@ export default {
         markdown: context.state.config.lex.initialText,
       },
     });
+    context.dispatch('sendInitialUtterance');
   },
   changeLocaleIds(context, data) {
     context.commit('updateLocaleIds', data);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix the issue that only initial text is shown and initial utterance is not sent when a bot is reinitialized or a user clear history. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
