### PR TITLE
fix: enable to control to send initial utterance when history exists

### DIFF
--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -246,9 +246,13 @@ export default {
           'successfully initialized lex web ui version: ',
           this.$store.state.version,
         );
-        // after slight delay, send in initial utterance if it is defined.
-        // waiting for credentials to settle down a bit.
-        setTimeout(() => this.$store.dispatch('sendInitialUtterance'), 500);
+        // don't send intial utterance when history is preserved (i.e. messages except for initial text exist)
+        if (this.$store.state.config.ui.sendInitialUtteranceWhenSaveHistory == true || 
+            this.$store.state.messages.length <= 1) { 
+          // after slight delay, send in initial utterance if it is defined.
+          // waiting for credentials to settle down a bit.
+          setTimeout(() => this.$store.dispatch('sendInitialUtterance'), 500);
+        }
       })
       .catch((error) => {
         console.error('could not initialize application while mounting:', error);

--- a/lex-web-ui/src/config/config.dev.json
+++ b/lex-web-ui/src/config/config.dev.json
@@ -37,6 +37,7 @@
     "minButtonContent": "",
     "hideInputFieldsForButtonResponse": false,
     "pushInitialTextOnRestart": false,
+    "sendInitialUtteranceWhenSaveHistory": true,
     "directFocusToBotInput": false,
     "showDialogStateIcon": false,
     "backButton": false,

--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -180,6 +180,10 @@ const configDefault = {
     // list after the bot dialog is done (i.e. fail or fulfilled)
     pushInitialTextOnRestart: true,
 
+    // send initial utterance only when history doesn't exist
+    // this option is effective when the saveHistory option is true
+    sendInitialUtteranceWhenSaveHistory: true,
+
     // controls if the Lex sessionAttributes should be re-initialized
     // to the config value (i.e. lex.sessionAttributes)
     // after the bot dialog is done (i.e. fail or fulfilled)

--- a/src/config/default-lex-web-ui-loader-config.json
+++ b/src/config/default-lex-web-ui-loader-config.json
@@ -40,6 +40,7 @@
     "minButtonContent": "",
     "hideInputFieldsForButtonResponse": false,
     "pushInitialTextOnRestart": false,
+    "sendInitialUtteranceWhenSaveHistory": true,
     "directFocusToBotInput": false,
     "showDialogStateIcon": false,
     "backButton": false,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently even if history exists (i.e. saveHistory=true), an initial utterance is sent every time a user refreshes a chat. However, saving history sometimes means the user wants to keep conversation and doesn't need the utterance sent. 
This PR introduces the config variable _sendInitialUtteranceWhenSaveHistory_ which enables developers to control if the initial utterance should be sent at initialization when history exists. 
To decide if messages are saved, I am checking if the lenght of the message list is less than one, meaning the list includes at most an initial text pushed at the earlier stage of the initialization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
