### PR TITLE
Switch lexwebui cloudfront distribution to use managed CachePolicyId and OriginRequestPolicyId.

### DIFF
--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -474,12 +474,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true

--- a/templates/pipeline.yaml
+++ b/templates/pipeline.yaml
@@ -393,12 +393,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true


### PR DESCRIPTION
Change lexwebui cloudfront distribution templates to use managed CachePolicyId and OriginRequestPolicyId. This establishes correct policies to cache origin headers properly from browsers notably safari and chrome. 

This addresses a problem where a subsequent reload of a page hosting lexwebui via iframe fails with CORS error when re-loading the lex-web-ui-loader-config.json file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
