### PR TITLE
Feature/local help

### DIFF
--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -217,6 +217,29 @@ const configDefault = {
     // shows a help button on the toolbar when true
     helpIntent: '',
 
+    // allowsConfigurableHelpContent - adding default content disables sending the helpIntent message.
+    // content can be added per locale as needed. responseCard is optional.
+    //     helpContent: {
+    //       en_US: {
+    //         text: "",
+    //         markdown: "",
+    //         responseCard: {
+    //           "title":"",
+    //           "subTitle":"",
+    //           "imageUrl":"",
+    //           "attachmentLinkUrl":"",
+    //           "buttons":[
+    //             {
+    //               "text":"",
+    //               "value":""
+    //             }
+    //           ]
+    //         }
+    //       }
+    //     }
+    helpContent: {
+    },
+
     // for instances when you only want to show error icons and feedback
     showErrorIcon: true,
 

--- a/src/config/default-lex-web-ui-loader-config.json
+++ b/src/config/default-lex-web-ui-loader-config.json
@@ -32,6 +32,7 @@
     "positiveFeedbackIntent": "Thumbs up",
     "negativeFeedbackIntent": "Thumbs down",
     "helpIntent": "Help",
+    "helpContent": {},
     "enableLogin": false,
     "enableSFX": false,
     "forceLogin": false,

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -474,12 +474,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true

--- a/templates/pipeline.yaml
+++ b/templates/pipeline.yaml
@@ -393,12 +393,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true


### PR DESCRIPTION
*Description of changes:*
Adds the ability to manually configure a help message in lex-web-ui-loader-config.json per locale. This message is displayed in response to clicking the help button rather then sending to the lex bot. In addition, the last message from the bot is re-displayed after the help message giving the user context on next action again. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
