### PR TITLE
Feature/multiple lex v2 image repsonse cards

### DIFF
--- a/lex-web-ui/src/components/Message.vue
+++ b/lex-web-ui/src/components/Message.vue
@@ -118,6 +118,22 @@
         >
         </response-card>
       </v-flex>
+      <v-flex
+        v-if="shouldDisplayResponseCardV2"
+      >
+        <v-flex v-for="(item, index) in message.responseCardsLexV2"
+          class="response-card"
+          d-flex
+          mt-2 mr-2 ml-3
+        >
+        <response-card
+          v-for="(card, index) in item.genericAttachments"
+          v-bind:response-card="card"
+          v-bind:key="index"
+        >
+        </response-card>
+        </v-flex>
+      </v-flex>
     </v-layout>
   </v-flex>
 </template>
@@ -152,6 +168,7 @@ export default {
       positiveClick: false,
       negativeClick: false,
       hasButtonBeenClicked: false,
+      disableCardButtons: false,
       positiveIntent: this.$store.state.config.ui.positiveFeedbackIntent,
       negativeIntent: this.$store.state.config.ui.negativeFeedbackIntent,
       hideInputFields: this.$store.state.config.ui.hideInputFieldsForButtonResponse,
@@ -210,6 +227,11 @@ export default {
         this.message.responseCard.genericAttachments instanceof Array
       );
     },
+    shouldDisplayResponseCardV2() {
+      return (
+        this.message.responseCardsLexV2 && this.message.responseCardsLexV2.length > 0
+      );
+    },
     shouldShowAvatarImage() {
       if (this.message.type === 'bot') {
         return this.botAvatarUrl;
@@ -228,7 +250,19 @@ export default {
       return this.$store.state.config.ui.showMessageDate;
     },
   },
+  provide: function () {
+    return {
+      getRCButtonsDisabled: this.getRCButtonsDisabled,
+      setRCButtonsDisabled: this.setRCButtonsDisabled
+    }
+  },
   methods: {
+    setRCButtonsDisabled: function() {
+      this.disableCardButtons = true;
+    },
+    getRCButtonsDisabled: function() {
+      return this.disableCardButtons;
+    },
     resendMessage(messageText) {
       const message = {
         type: 'human',

--- a/lex-web-ui/src/components/ResponseCard.vue
+++ b/lex-web-ui/src/components/ResponseCard.vue
@@ -71,14 +71,15 @@ export default {
     shouldDisableClickedResponseCardButtons() {
       return (
         this.$store.state.config.ui.shouldDisableClickedResponseCardButtons &&
-        this.hasButtonBeenClicked
+        (this.hasButtonBeenClicked || this.getRCButtonsDisabled())
       );
     },
   },
+  inject: ['getRCButtonsDisabled','setRCButtonsDisabled'],
   methods: {
     onButtonClick(value) {
       this.hasButtonBeenClicked = true;
-
+      this.setRCButtonsDisabled();
       const messageType = this.$store.state.config.ui.hideButtonMessageBubble ? 'button' : 'human';
       const message = {
         type: messageType,

--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -217,6 +217,29 @@ const configDefault = {
     // shows a help button on the toolbar when true
     helpIntent: '',
 
+    // allowsConfigurableHelpContent - adding default content disables sending the helpIntent message.
+    // content can be added per locale as needed. responseCard is optional.
+    //     helpContent: {
+    //       en_US: {
+    //         text: "",
+    //         markdown: "",
+    //         responseCard: {
+    //           "title":"",
+    //           "subTitle":"",
+    //           "imageUrl":"",
+    //           "attachmentLinkUrl":"",
+    //           "buttons":[
+    //             {
+    //               "text":"",
+    //               "value":""
+    //             }
+    //           ]
+    //         }
+    //       }
+    //     }
+    helpContent: {
+    },
+
     // for instances when you only want to show error icons and feedback
     showErrorIcon: true,
 

--- a/lex-web-ui/src/lib/lex/client.js
+++ b/lex-web-ui/src/lib/lex/client.js
@@ -255,13 +255,16 @@ export default class {
           const finalMessages = [];
           if (res.messages && res.messages.length > 0) {
             res.messages = b64CompressedToObject(res.messages);
+            res.responseCardLexV2 = [];
             res.messages.forEach((mes) => {
               if (mes.contentType === 'ImageResponseCard') {
-                res.responseCard = {};
-                res.responseCard.version = '1';
-                res.responseCard.contentType = 'application/vnd.amazonaws.card.generic';
-                res.responseCard.genericAttachments = [];
-                res.responseCard.genericAttachments.push(mes.imageResponseCard);
+                res.responseCardLexV2 = res.responseCardLexV2 ? res.responseCardLexV2 : [];
+                const newCard = {};
+                newCard.version = '1';
+                newCard.contentType = 'application/vnd.amazonaws.card.generic';
+                newCard.genericAttachments = [];
+                newCard.genericAttachments.push(mes.imageResponseCard);
+                res.responseCardLexV2.push(newCard);
               } else {
                 /* eslint-disable no-lonely-if */
                 if (mes.contentType) { // push v1 style messages for use in the UI

--- a/lex-web-ui/src/lib/lex/client.js
+++ b/lex-web-ui/src/lib/lex/client.js
@@ -163,11 +163,13 @@ export default class {
           if (res.messages && res.messages.length > 0) {
             res.messages.forEach((mes) => {
               if (mes.contentType === 'ImageResponseCard') {
-                res.responseCard = {};
-                res.responseCard.version = '1';
-                res.responseCard.contentType = 'application/vnd.amazonaws.card.generic';
-                res.responseCard.genericAttachments = [];
-                res.responseCard.genericAttachments.push(mes.imageResponseCard);
+                res.responseCardLexV2 = res.responseCardLexV2 ? res.responseCardLexV2 : [];
+                const newCard = {};
+                newCard.version = '1';
+                newCard.contentType = 'application/vnd.amazonaws.card.generic';
+                newCard.genericAttachments = [];
+                newCard.genericAttachments.push(mes.imageResponseCard);
+                res.responseCardLexV2.push(newCard);
               } else {
                 /* eslint-disable no-lonely-if */
                 if (mes.contentType) { // push v1 style messages for use in the UI

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -532,6 +532,7 @@ export default {
                       responseCard: tmsg.messages.length - 1 === index // attach response card only
                         ? responseCardObject : undefined, // for last response message
                       alts,
+                      responseCardsLexV2: response.responseCardLexV2
                     },
                   );
                 });

--- a/lex-web-ui/src/store/recorder-handlers.js
+++ b/lex-web-ui/src/store/recorder-handlers.js
@@ -122,9 +122,14 @@ const initRecorderHandlers = (context, recorder) => {
                   audio: lexAudioUrl,
                   text: mes.value,
                   dialogState: context.state.lex.dialogState,
-                  responseCard: context.state.lex.responseCard,
                   alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
-                  responseCardsLexV2: context.state.lex.responseCardLexV2
+                  // Only provide response cards in voice response if intent is Failed or Fulfilled.
+                  // Response card button selection while waiting for voice interaction during intent fulfillment
+                  // leads to errors in LexWebUi.
+                  responseCard: (context.state.lex.sessionState.intent.state === 'Failed' ||
+                    context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCard : null,
+                  responseCardsLexV2: (context.state.lex.sessionState.intent.state === 'Failed' ||
+                    context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCardLexV2 : null
                 },
               );
             });
@@ -135,9 +140,14 @@ const initRecorderHandlers = (context, recorder) => {
             audio: lexAudioUrl,
             text: context.state.lex.message,
             dialogState: context.state.lex.dialogState,
-            responseCard: context.state.lex.responseCard,
             alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
-            responseCardsLexV2: context.state.lex.responseCardLexV2
+            // Only provide response cards in voice response if intent is Failed or Fulfilled.
+            // Response card button selection while waiting for voice interaction during intent fulfillment
+            // leads to errors in LexWebUi.
+            responseCard: (context.state.lex.sessionState.intent.state === 'Failed' ||
+              context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCard : null,
+            responseCardsLexV2: (context.state.lex.sessionState.intent.state === 'Failed' ||
+              context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCardLexV2 : null
           });
         }
         return context.dispatch('playAudio', lexAudioUrl, {}, offset);

--- a/lex-web-ui/src/store/recorder-handlers.js
+++ b/lex-web-ui/src/store/recorder-handlers.js
@@ -124,6 +124,7 @@ const initRecorderHandlers = (context, recorder) => {
                   dialogState: context.state.lex.dialogState,
                   responseCard: context.state.lex.responseCard,
                   alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
+                  responseCardsLexV2: context.state.lex.responseCardLexV2
                 },
               );
             });
@@ -136,6 +137,7 @@ const initRecorderHandlers = (context, recorder) => {
             dialogState: context.state.lex.dialogState,
             responseCard: context.state.lex.responseCard,
             alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
+            responseCardsLexV2: context.state.lex.responseCardLexV2
           });
         }
         return context.dispatch('playAudio', lexAudioUrl, {}, offset);

--- a/lex-web-ui/src/store/recorder-handlers.js
+++ b/lex-web-ui/src/store/recorder-handlers.js
@@ -123,13 +123,13 @@ const initRecorderHandlers = (context, recorder) => {
                   text: mes.value,
                   dialogState: context.state.lex.dialogState,
                   alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
-                  // Only provide response cards in voice response if intent is Failed or Fulfilled.
+                  responseCard: context.state.lex.responseCard,
+                  // Only provide V2 response cards in voice response if intent is Failed or Fulfilled.
                   // Response card button selection while waiting for voice interaction during intent fulfillment
                   // leads to errors in LexWebUi.
-                  responseCard: (context.state.lex.sessionState.intent.state === 'Failed' ||
-                    context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCard : null,
-                  responseCardsLexV2: (context.state.lex.sessionState.intent.state === 'Failed' ||
-                    context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCardLexV2 : null
+                  responseCardsLexV2: (context.state.lex.sessionState && context.state.lex.sessionState.intent &&
+                    (context.state.lex.sessionState.intent.state === 'Failed' ||
+                      context.state.lex.sessionState.intent.state === 'Fulfilled')) ? context.state.lex.responseCardLexV2 : null
                 },
               );
             });
@@ -140,14 +140,8 @@ const initRecorderHandlers = (context, recorder) => {
             audio: lexAudioUrl,
             text: context.state.lex.message,
             dialogState: context.state.lex.dialogState,
+            responseCard: context.state.lex.responseCard,
             alts: JSON.parse(context.state.lex.sessionAttributes.appContext || '{}').altMessages,
-            // Only provide response cards in voice response if intent is Failed or Fulfilled.
-            // Response card button selection while waiting for voice interaction during intent fulfillment
-            // leads to errors in LexWebUi.
-            responseCard: (context.state.lex.sessionState.intent.state === 'Failed' ||
-              context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCard : null,
-            responseCardsLexV2: (context.state.lex.sessionState.intent.state === 'Failed' ||
-              context.state.lex.sessionState.intent.state === 'Fulfilled') ? context.state.lex.responseCardLexV2 : null
           });
         }
         return context.dispatch('playAudio', lexAudioUrl, {}, offset);

--- a/src/config/default-lex-web-ui-loader-config.json
+++ b/src/config/default-lex-web-ui-loader-config.json
@@ -32,6 +32,7 @@
     "positiveFeedbackIntent": "Thumbs up",
     "negativeFeedbackIntent": "Thumbs down",
     "helpIntent": "Help",
+    "helpContent": {},
     "enableLogin": false,
     "enableSFX": false,
     "forceLogin": false,

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -474,12 +474,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true

--- a/templates/pipeline.yaml
+++ b/templates/pipeline.yaml
@@ -393,12 +393,8 @@ Resources:
                 - OPTIONS
               Compress: true
               TargetOriginId: webuiorigin
-              ForwardedValues:
-                QueryString: true
-                Headers:
-                  - Origin
-                  - Access-Control-Request-Method
-                  - Access-Control-Request-Headers
+              CachePolicyId: "658327ea-f89d-4fab-a63d-7e88639e58f6"
+              OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
             ViewerCertificate:
               CloudFrontDefaultCertificate: true


### PR DESCRIPTION
*Issue #, if available:*
347

*Description of changes:*

Feature to handle multiple Lex V2 ImageResponseCards returned via Lambda. Separates Lex V1 ResponseCard from Lex V2 ResponseCard in client response. Implements two v-flex areas to handle either V1 or V2 response cards. Ensures a button click in any of the ResponseCards, disables buttons across all response cards for that specific message array. 

This pull request also includes:

PR #345 - Switch lexwebui cloudfront distribution to use managed CachePolicyId and OriginRequestPolicyId.

PR #348 - Feature/local help

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
