### PR TITLE
Feature/live chat attr

### DIFF
--- a/lex-web-ui/src/components/InputContainer.vue
+++ b/lex-web-ui/src/components/InputContainer.vue
@@ -319,5 +319,12 @@ export default {
 .input-container {
   /* make footer same height as dense toolbar */
   min-height: 48px;
+  position: fixed;
+  bottom: 0;
+  bottom: env(safe-area-inset-bottom);
+  left: 0;
+  left: env(safe-area-inset-left);
+  right: 0;
+  right: env(safe-area-inset-right);
 }
 </style>

--- a/lex-web-ui/src/components/ToolbarContainer.vue
+++ b/lex-web-ui/src/components/ToolbarContainer.vue
@@ -408,6 +408,15 @@ export default {
         )
       )
     },
+    shouldRepeatLastMessage() {
+      const localeId = this.$store.state.config.lex.v2BotLocaleId ? this.$store.state.config.lex.v2BotLocaleId : 'en_US';
+      const helpContent = this.$store.state.config.ui.helpContent;
+      console.log('inside repeat message');
+      if(helpContent && helpContent[localeId] && (helpContent[localeId].repeatLastMessage === undefined ? true : helpContent[localeId].repeatLastMessage)) {
+        return true;
+      }
+      return false;
+    },
     messageForHelpContent() {
       const localeId = this.$store.state.config.lex.v2BotLocaleId ? this.$store.state.config.lex.v2BotLocaleId : 'en_US';
       const helpContent = this.$store.state.config.ui.helpContent;
@@ -447,7 +456,7 @@ export default {
           currentMessage = this.$store.state.messages[this.$store.state.messages.length-1];
         }
         this.$store.dispatch('pushMessage', this.messageForHelpContent());
-        if (currentMessage) {
+        if (currentMessage && this.shouldRepeatLastMessage()) {
           this.$store.dispatch('pushMessage', currentMessage);
         }
       } else {

--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -221,9 +221,10 @@ const configDefault = {
     // content can be added per locale as needed. responseCard is optional.
     //     helpContent: {
     //       en_US: {
-    //         text: "",
-    //         markdown: "",
-    //         responseCard: {
+    //         "text": "",
+    //         "markdown": "",
+    //         "repeatLastMessage": true,
+    //         "responseCard": {
     //           "title":"",
     //           "subTitle":"",
     //           "imageUrl":"",

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -479,7 +479,9 @@ export default {
       })
       .then(() => {
         const liveChatTerms = context.state.config.connect.liveChatTerms ? context.state.config.connect.liveChatTerms.split(',').map(str => str.trim()) : [];
-        if (context.state.config.ui.enableLiveChat && liveChatTerms.find(el => el === message.text.toLowerCase())) {
+        if (context.state.config.ui.enableLiveChat && 
+          liveChatTerms.find(el => el === message.text.toLowerCase()) && 
+          context.state.chatMode !== chatMode.LIVECHAT) {
           return context.dispatch('requestLiveChat');
         } else if (context.state.liveChat.status === liveChatStatus.REQUEST_USERNAME) {
           context.commit('setLiveChatUserName', message.text);

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -481,7 +481,7 @@ export default {
         const liveChatTerms = context.state.config.connect.liveChatTerms ? context.state.config.connect.liveChatTerms.split(',').map(str => str.trim()) : [];
         if (context.state.config.ui.enableLiveChat && 
           liveChatTerms.find(el => el === message.text.toLowerCase()) && 
-          context.state.chatMode !== chatMode.LIVECHAT) {
+          context.state.chatMode === chatMode.BOT) {
           return context.dispatch('requestLiveChat');
         } else if (context.state.liveChat.status === liveChatStatus.REQUEST_USERNAME) {
           context.commit('setLiveChatUserName', message.text);

--- a/templates/master.yaml
+++ b/templates/master.yaml
@@ -348,11 +348,13 @@ Parameters:
         Type: String
         Description: >
             Connect Contract Flow Id
+        Default: ''
 
     ConnectInstanceId:
         Type: String
         Description: >
             Connect Instance Id
+        Default: ''
 
     ConnectPromptForNameMessage:
         Type: String


### PR DESCRIPTION
*Description of changes:*

Fix: CSS for iOS 15/Safari for input container to be visible on screen
Fix: Default value for Connect ContactId & InstanceId as empty string to facilitate CLI
Fix: Prevent users from entering live chat multiple times if they type the 'live chat' message
Added:  Flag for the 'offline help' to repeat or not repeat the last received message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
