### PR TITLE
Pass lexSessionAttributes to Connect as contact attibute during chat initiation

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -819,6 +819,7 @@ export default {
       },
       ContactFlowId: context.state.config.connect.contactFlowId,
       InstanceId: context.state.config.connect.instanceId,
+      lexSessionAttributes: context.state.lex.sessionAttributes,
     };
 
     const uri = new URL(context.state.config.connect.apiGatewayEndpoint);

--- a/src/initiate-chat-lambda/index.js
+++ b/src/initiate-chat-lambda/index.js
@@ -49,13 +49,20 @@ function startChatContact(body) {
                     
     }
 
+    let lexSessionAttributes = "";
+    if (body.hasOwnProperty("lexSessionAttributes")) {
+            lexSessionAttributes = body["lexSessionAttributes"];
+                    
+    }
+
     return new Promise(function(resolve, reject) {
         const startChat = {
             "InstanceId": instanceId == "" ? process.env.INSTANCE_ID : instanceId,
             "ContactFlowId": contactFlowId == "" ? process.env.CONTACT_FLOW_ID : contactFlowId,
             "Attributes": {
                 "customerName": body["ParticipantDetails"]["DisplayName"],
-                "topic" : topic
+                "topic" : topic,
+                "lexSessionAttributes": lexSessionAttributes
             },
             "ParticipantDetails": {
                 "DisplayName": body["ParticipantDetails"]["DisplayName"]


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Changes in lex-web-ui/src/store/actions.js to pass lexSessionAttributes to initiate-chat-lambda. 
Changes in src/initiate-chat-lambda/index.js to pass lexSessionAttributes to Connect on chat initiation as Contact Attribute.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
