### PR TITLE
Adding framework to programatically control tease bubble

### DIFF
--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -7,7 +7,7 @@
       <div class="message-list-wrapper-inside" id="tease-bubble"></div>
       <div
         id="dismissIcon"
-        v-on:click.stop="hideTeaseBubble"
+        v-on:click.stop="disableTeaseBubble"
         onclick="this.parentNode.classList.add('tease-bubble-display-none'); return false;"
       >
         <svg
@@ -335,7 +335,7 @@ export default {
         this.toolbarHeightClassSuffix = "lg";
       }
     },
-    hideTeaseBubble() {
+    disableTeaseBubble() {
       this.$emit("hideTeaseBubble");
       this.$store.commit("setUserWantsTeaseBubble", false);
       return this.$store.dispatch("hideTeaseBubble");
@@ -489,7 +489,11 @@ export default {
             });
           });
           break;
-        case "showTeaseBubble":
+        // if programatically calling this method, will override user's tease bubble preferences
+        // to show/hide tease bubbles. All other implementations of show/hideTeaseBubble only affect the current display
+        // status of the tease bubble and not the user preference for enabling/disabling the feature.
+        case "enableTeaseBubble":
+          this.$store.commit("setUserWantsTeaseBubble", true);
           this.$store.dispatch("showTeaseBubble").then(() =>
             evt.ports[0].postMessage({
               event: "resolve",
@@ -497,7 +501,12 @@ export default {
             })
           );
           break;
-        case "hideTeaseBubble":
+        case "disableTeaseBubble":
+          let messageListWrapper = document.getElementsByClassName(
+            "message-list-wrapper"
+          )[0];
+          messageListWrapper.classList.add("tease-bubble-display-none");
+          this.$store.commit("setUserWantsTeaseBubble", false);
           this.$store.dispatch("hideTeaseBubble").then(() =>
             evt.ports[0].postMessage({
               event: "resolve",

--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -512,9 +512,6 @@ export default {
             if (tmsg && Array.isArray(tmsg.messages)) {
               tmsg.messages.forEach((mes, index) => {
                 let alts = JSON.parse(response.sessionAttributes.appContext || '{}').altMessages;
-                if (alts.tease) {
-                  context.dispatch("parseTeaseBubbleText", alts.tease);
-                }
                 if (mes.type === 'CustomPayload' || mes.contentType === 'CustomPayload') {
                   if (alts === undefined) {
                     alts = {};
@@ -547,9 +544,6 @@ export default {
           }
         } else {
           let alts = JSON.parse(response.sessionAttributes.appContext || '{}').altMessages;
-          if (alts.tease) {
-            context.dispatch("parseTeaseBubbleText", alts.tease);
-          }
           let responseCardObject = JSON.parse(response.sessionAttributes.appContext || '{}').responseCard;
           if (response.messageFormat === 'CustomPayload') {
             if (alts === undefined) {
@@ -751,6 +745,11 @@ export default {
         'sendMessageToParentWindow',
         { event: 'updateLexState', state: context.state.lex },
       );
+    }
+
+    // check for tease bubble stuff after all this is done.
+    if (lexState?.sessionAttributes?.teaseBubble?.teaseText) {
+      context.dispatch('parseTeaseBubbleText', JSON.parse(lexState.sessionAttributes.teaseBubble).teaseText);
     }
     return Promise.resolve();
   },
@@ -1177,7 +1176,7 @@ export default {
   setSessionAttrs(context, attrs) {
     context.commit('setSessionAttrs', attrs);
   },
-  // show tease bubble if alts.tease exists in postText message response
+  // show tease bubble if tease exists in new state returned from lex Client
   parseTeaseBubbleText(context, tease) {
     let teaseText = marked(tease, { renderer });
     teaseText = teaseText.trim();

--- a/lex-web-ui/src/store/state.js
+++ b/lex-web-ui/src/store/state.js
@@ -94,7 +94,7 @@ export default {
   isSFXOn: (config.ui) ? (!!config.ui.enableSFX &&
     !!config.ui.messageSentSFX && !!config.ui.messageReceivedSFX) : false,
   isUiMinimized: false, // when running embedded, is the iframe minimized?
-  userWantsTeaseBubble: false, // tease bubble is not shown on page load
+  userWantsTeaseBubble: true, // tease bubble is shown on page load
   isEnableLogin: false, // true when a login/logout menu should be displayed
   isForceLogin: false, // true when a login/logout menu should be displayed
   isLoggedIn: false, // when running with login/logout enabled

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -87,23 +87,25 @@ export class IframeComponentLoader {
       .then(() => this.initCustomSetup());
   }
 
-  // custom events for Rhode Island.
+  // custom events.
   initCustomSetup() {
     // store user pool id for the parent page to use.
     if (this.config.cognito.appUserPoolClientId) {
-      localStorage.setItem('appUserPoolClientId', `${this.config.cognito.appUserPoolClientId}`);
+      localStorage.setItem("appUserPoolClientId", `${this.config.cognito.appUserPoolClientId}`);
     }
 
-    // if user clicks out of iframe, minimize the chatbot.
-    document.body.onclick = () => {
-      if (localStorage?.appUserPoolClientId && (localStorage[`${localStorage?.appUserPoolClientId}lastUiIsMinimized`] === 'false')) {
-        // document.dispatchEvent(new CustomEvent('lexWebUiMessage', { detail: { message: {event: "toggleMinimizeUi"}}}));
-        this.sendMessageToIframe({ event: 'toggleMinimizeUi' });
+    // minimize the chatbot if user clicks out of it or not. Based on user pref from config.
+    // we can't access Vue state from here; instead, use localStorage to track chatbot minimize state
+    if (this.config.ui.autoMinimizeOnUnfocus) {
+      document.body.onclick = () => {
+        if (localStorage?.appUserPoolClientId && (localStorage[`${localStorage?.appUserPoolClientId}lastUiIsMinimized`] == "false")) {
+          this.sendMessageToIframe({ event: 'toggleMinimizeUi' })
+        }
       }
-    };
+    }
 
-    // on load, ask UIO+ for new Cognito tokens for custom session attributes.
-    window.setTimeout(() => document.dispatchEvent(new Event('requestSessionAttrs')), 2000);
+    // dispatch a signal that lets parent page know the chatbot is ready to accept information.
+    document.dispatchEvent(new Event('chatbotReady'));
   }
 
   /**

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -603,7 +603,7 @@ export class IframeComponentLoader {
       },
 
       hideTeaseBubble(evt) {
-        this.hideTeaseBubbleStateClass()
+        this.hideTeaseBubbleClass()
           .then(() => (
             evt.ports[0].postMessage({ event: 'resolve', type: evt.data.event })
           ))
@@ -803,7 +803,7 @@ export class IframeComponentLoader {
   /**
    * Remove partially minimized class
    */
-  hideTeaseBubbleStateClass() {
+  hideTeaseBubbleClass() {
     try {
       this.containerElement.classList.remove(`${this.containerClass}--partially-minimized`);
       return Promise.resolve();
@@ -876,11 +876,11 @@ export class IframeComponentLoader {
         // check for last state and resume with this configuration
         if (this.config.iframe.shouldLoadIframeMinimized) {
           this.api.toggleMinimizeUi();
-          this.api.showTeaseBubble();
+          this.api.enableTeaseBubble();
           localStorage.setItem(`${this.config.cognito.appUserPoolClientId}lastUiIsMinimized`, 'true');
         } else if (localStorage.getItem(`${this.config.cognito.appUserPoolClientId}lastUiIsMinimized`) && localStorage.getItem(`${this.config.cognito.appUserPoolClientId}lastUiIsMinimized`) === 'true') {
           this.api.toggleMinimizeUi();
-          this.api.showTeaseBubble();
+          this.api.enableTeaseBubble();
         } else if (localStorage.getItem(`${this.config.cognito.appUserPoolClientId}lastUiIsMinimized`) && localStorage.getItem(`${this.config.cognito.appUserPoolClientId}lastUiIsMinimized`) === 'false') {
           this.api.ping();
         }
@@ -912,14 +912,14 @@ export class IframeComponentLoader {
       sendParentReady: () => (
         this.sendMessageToIframe({ event: 'parentReady' })
       ),
-      showTeaseBubble: () => (
-        this.sendMessageToIframe({ event: 'showTeaseBubble' })
+      enableTeaseBubble: () => (
+        this.sendMessageToIframe({ event: 'enableTeaseBubble' })
       ),
       toggleTheme: () => (
         this.sendMessageToIframe({ event: 'toggleTheme' })
       ),
-      hideTeaseBubble: () => (
-        this.sendMessageToIframe({ event: 'hideTeaseBubble' })
+      disableTeaseBubble: () => (
+        this.sendMessageToIframe({ event: 'disableTeaseBubble' })
       ),
       toggleMinimizeUi: () => (
         this.sendMessageToIframe({ event: 'toggleMinimizeUi' })


### PR DESCRIPTION
Updating parent calls to control the tease bubble by providing the parent control over the entire tease bubble feature being enabled/disabled, rather than just showing or hiding the bubble.
