### PR TITLE
Fixes for cfn templates and livechat

### DIFF
--- a/templates/master-pipeline.yaml
+++ b/templates/master-pipeline.yaml
@@ -440,13 +440,13 @@ Resources:
             TemplateURL: !Sub "https://${BootstrapBucket}.s3.${AWS::Region}.amazonaws.com/${BootstrapPrefix}/templates/pipeline.yaml"
             Parameters:
                 BotName:
-                  !If
-                    - IsLexV2
-                    - !Ref LexV2BotId
-                    - !If
-                        - NeedsBot
-                        - !GetAtt Bot.Outputs.BotName
-                        - !Ref BotName
+                  #!If
+                  #  - IsLexV2
+                  #  - !Ref LexV2BotId
+                    !If
+                      - NeedsBot
+                      - !GetAtt Bot.Outputs.BotName
+                      - !Ref BotName
                 BotAlias: !Ref BotAlias
                 LexV2BotId: !Ref LexV2BotId
                 LexV2BotAliasId: !Ref LexV2BotAliasId
@@ -461,6 +461,7 @@ Resources:
                       - !Ref CognitoIdentityPoolId
                 ParentOrigin: !Ref WebAppParentOrigin
                 CustomResourceCodeBucket: !Ref BootstrapBucket
+                CustomResourceCodePrefix: !Ref BootstrapPrefix
                 CustomResourceCodeObject: !Sub "${BootstrapPrefix}/custom-resources-v0.19.4.zip"
                 InitiateChatLambdaCodeObject: !Sub "${BootstrapPrefix}/initiate-chat-lambda-v0.19.4.zip"
                 CleanupBuckets: !Ref CleanupBuckets

--- a/templates/pipeline.yaml
+++ b/templates/pipeline.yaml
@@ -77,6 +77,7 @@ Parameters:
         also enter your Bot alias ID in the LexV2BotAliasId field below.
       Type: String
       Default: ''
+      MinLength: 0
       MaxLength: 50
       AllowedPattern: '(^$|^[a-zA-Z0-9]+((_[a-zA-Z0-9]+)*|([a-zA-Z0-9]+_)*|_))'
       ConstraintDescription: >
@@ -105,28 +106,31 @@ Parameters:
       MaxLength: 50
 
     BotName:
-        Type: String
         Description: >
-            Name of Lex bot to be used in the web app configuration.
-        MinLength: 2
+            Name of an existing Lex Bot to be used by the web ui. NOTE: You must
+            also enter your published bot alias in the BotAlias field below. DO NOT MODIFY this value if
+            configuring a V2 Bot.
+        Type: String
+        Default: ''
+        MinLength: 0
         MaxLength: 50
-        AllowedPattern: '^[a-zA-Z]+((_[a-zA-Z]+)*|([a-zA-Z]+_)*|_)'
+        AllowedPattern: '(^$|^[a-zA-Z]+((_[a-zA-Z]+)*|([a-zA-Z]+_)*|_))'
         ConstraintDescription: >
             Must conform with the permitted Lex Bot name pattern.
 
     BotAlias:
-      Description: >
-        WARNING: For production deployments, use your bot's published alias here.
-        The $LATEST alias should only be used for manual testing. Amazon Lex limits
-        the number of runtime requests that you can make to the $LATEST version of
-        the bot.
-      Type: String
-      Default: '$LATEST'
-      MinLength: 2
-      MaxLength: 50
-      AllowedPattern: '(^$|^[$a-zA-Z]+((_[$a-zA-Z]+)*|([$a-zA-Z]+_)*|_))'
-      ConstraintDescription: >
-        Must conform with the permitted Lex Alias name pattern.
+        Description: >
+            WARNING: For production deployments, use your bot's published alias here.
+            The $LATEST alias should only be used for manual testing. Amazon Lex limits
+            the number of runtime requests that you can make to the $LATEST version of
+            the bot. DO NOT MODIFY this value if configuring a V2 Bot.
+        Type: String
+        Default: '$LATEST'
+        MinLength: 2
+        MaxLength: 50
+        AllowedPattern: '(^$|^[$a-zA-Z]+((_[$a-zA-Z]+)*|([$a-zA-Z]+_)*|_))'
+        ConstraintDescription: >
+            Must conform with the permitted Lex Alias name pattern.
 
     ParentOrigin:
         Type: String


### PR DESCRIPTION
*Issue #, if available:*  N/A

*Description of changes:*
Discovered that the CloudFormation template to deploy a CI/CD Pipeline for Lex-Web-UI would fail on the attempt to create the Pipeline resource.  This was because the Pipeline template had Properties for Lex v1 BotName which required a minimum of 2 characters so deploying the Pipeline expected a value even if deploying for a Lex v2 environment.  The master-pipeline.yaml was updated to remove the IF statement in the Pipeline resource since it wasn't needed after fixing the BotName and BotAlias properties in the Pipeline.yaml file.  There was also an issue creating the RestAPI within the Pipeline.yaml because the path to the CloudFormation template for the RestAPI.yaml was not correct so the master-pipeline.yaml was updated to add a line to pass the BootstrapPrefix to the CustomResourceCodePrefix property.

There is another commit which addresses an issue with the Live Chat feature of Lex-Web-UI.  The issue was that if a customer entered a name which matched the name of the agent that was answering the chat the Lex-Web-UI would not recognize that the agent had connected.  This would mean that the agent would not see the chat transcript/history from the customer and the customer would continue to see the prompt about waiting for an agent to join even though they could actively chat with the agent. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
