### PR TITLE
Do not allow V1 & V2 values simultaneously

### DIFF
--- a/templates/master-pipeline.yaml
+++ b/templates/master-pipeline.yaml
@@ -324,6 +324,18 @@ Parameters:
             When pressed the button will send the entered string to the bot as a help message.  If left empty
             the help button will be disabled.
 
+Rules:
+  ValidateEitherV1orV2:
+    RuleCondition: !Not 
+        - !Equals
+            - !Ref BotName
+            - ''
+    Assertions:
+      - Assert: !Equals 
+            - !Ref LexV2BotId
+            - ''
+        AssertDescription: 'Template cannot contain both Lex V1 and Lex V2 information'
+        
 Metadata:
     AWS::CloudFormation::Interface:
         ParameterGroups:
@@ -513,7 +525,7 @@ Resources:
                 CodeBuildProjectName: !Ref CodeBuildName
                 CognitoUserPool: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolId
                 CognitoUserPoolClient: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolClientId
-                Timestamp: 1665984339
+                Timestamp: 1666965985
 
 Outputs:
     BotName:

--- a/templates/master.yaml
+++ b/templates/master.yaml
@@ -441,6 +441,18 @@ Parameters:
             Command separated list of terms that can be used to start Live Chat mode
         Default: "live chat"
 
+Rules:
+  ValidateEitherV1orV2:
+    RuleCondition: !Not 
+        - !Equals
+            - !Ref BotName
+            - ''
+    Assertions:
+      - Assert: !Equals 
+            - !Ref LexV2BotId
+            - ''
+        AssertDescription: 'Template cannot contain both Lex V1 and Lex V2 information'
+
 Metadata:
     AWS::CloudFormation::Interface:
         ParameterGroups:


### PR DESCRIPTION
Fix to prevent people from accidentally deploying V1/V2 bot values simultaneously in the template, which will cause an error downstream.