### PR TITLE
fix for max login tries exceeded error

### DIFF
--- a/src/lex-web-ui-loader/js/lib/loginutil.js
+++ b/src/lex-web-ui-loader/js/lib/loginutil.js
@@ -110,9 +110,11 @@ function login(config) {
   if (getLoopCount(config) < maxLoopCount) {
     const auth = getAuth(config);
     const session = auth.getSignInUserSession();
-    if (!session.isValid()) {
-      auth.getSession();
-    }
+     setTimeout(function () {
+      if ( !session.isValid()) {
+        auth.getSession();
+      }
+    }, 500);
   } else {
     alert("max login tries exceeded");
     localStorage.setItem(`${config.appUserPoolClientId}${loopKey}`, "0");


### PR DESCRIPTION
*#487*

**
to fix this issue, I just added timeout function before checking if the session is valid or not this timeout function makes sure that the token is fetched properly before the session validation. I don't know if this is the ideal way to do this, so any alternative suggestions will be helpful.
