### PR TITLE
Add the ability to configure a prebuild CNAME, ACM Certificate, and W…

### DIFF
--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -335,6 +335,26 @@ Parameters:
         Default: Order Flowers
         Description: Title displayed in the chatbot UI toolbar
 
+    WebAppConfCname:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a single CNAME to be defined and used as an alias to
+            the cloudfront distribution that is created by this template. If a CNAME is provided, a 
+            WebAppAcmCertificateArn must also be provided.
+
+    WebAppAcmCertificateArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AcmCertificateArn to be provided for use in the Cloudfront
+            distribution created by this template. if a AcmCertificateArn is provided, a WebAppConfCname must also
+            be provided.
+
+    WebAppWafAclArn:
+      Type: String
+      Default: ""
+      Description: This optional parameter allows a AWS WAF web ACL to be specified in ARN formation. This supports
+        AWS WAF V2.
+
     SaveHistory:
         Type: String
         Default: false
@@ -422,6 +442,8 @@ Conditions:
     NeedsParentOrigin: !Equals [!Ref ParentOrigin, '']
     ShouldCleanupBuckets: !Equals [!Ref CleanupBuckets, true]
     EnableLiveChat: !Equals [!Ref ShouldEnableLiveChat, true]
+    UseDefaultCloudfrontUrl: !Or [ !Equals [!Ref WebAppConfCname, ''], !Equals [!Ref WebAppAcmCertificateArn, ''] ]
+    ShouldNotSpecifyWafAcl: !Equals [!Ref WebAppWafAclArn, '']
 
 Resources:
     # Bucket where S3 access logs are stored
@@ -581,8 +603,23 @@ Resources:
               OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
               ResponseHeadersPolicyId: !GetAtt LexWebUIResponseHeaderPolicy.Id
+            Aliases:
+              !If
+                - UseDefaultCloudfrontUrl
+                - !Ref AWS::NoValue
+                - [ !Ref WebAppConfCname ]
             ViewerCertificate:
-              CloudFrontDefaultCertificate: true
+              !If
+                - UseDefaultCloudfrontUrl
+                - CloudFrontDefaultCertificate: true
+                - AcmCertificateArn: !Ref WebAppAcmCertificateArn
+                  MinimumProtocolVersion: TLSv1.2_2018
+                  SslSupportMethod: sni-only
+            WebACLId:
+              !If
+                - ShouldNotSpecifyWafAcl
+                - !Ref AWS::NoValue
+                - !Ref WebAppWafAclArn
             HttpVersion: http2
             IPV6Enabled: true
 
@@ -598,7 +635,11 @@ Resources:
               InitiateChatLambdaCodeObject: !Ref InitiateChatLambdaCodeObject
               ConnectContactFlowId: !Ref ConnectContactFlowId
               ConnectInstanceId: !Ref ConnectInstanceId
-              ParentOrigin: !Sub "https://${LexWebUiDistribution.DomainName}"
+              ParentOrigin:
+                !If
+                  - UseDefaultCloudfrontUrl
+                  - !Sub "https://${LexWebUiDistribution.DomainName}"
+                  - !Sub "https://${WebAppConfCname}"
 
     CodeBuild:
         Type: AWS::CodeBuild::Project

--- a/templates/master-pipeline.yaml
+++ b/templates/master-pipeline.yaml
@@ -324,6 +324,26 @@ Parameters:
             When pressed the button will send the entered string to the bot as a help message.  If left empty
             the help button will be disabled.
 
+    WebAppConfCname:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a single CNAME to be defined and used as an alias to
+            the cloudfront distribution that is created by this template. If a CNAME is provided, a
+            WebAppAcmCertificateArn must also be provided.
+
+    WebAppAcmCertificateArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AcmCertificateArn to be provided for use in the Cloudfront
+            distribution created by this template. if a AcmCertificateArn is provided, a WebAppConfCname must also
+            be provided.
+
+    WebAppWafAclArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AWS WAF web ACL to be specified in ARN formation. This supports
+            AWS WAF V2.
+
     ConnectStartLiveChatLabel:
         Type: String
         Description: >
@@ -401,6 +421,9 @@ Metadata:
                   - WebAppConfNegativeFeedback
                   - WebAppConfPositiveFeedback
                   - WebAppConfHelp
+                  - WebAppConfCname
+                  - WebAppAcmCertificateArn
+                  - WebAppWafAclArn
             - Label:
                 default: Connect Live Chat Parameters
               Parameters:
@@ -528,6 +551,9 @@ Resources:
                 WebAppConfNegativeFeedback: !Ref WebAppConfNegativeFeedback
                 WebAppConfPositiveFeedback: !Ref WebAppConfPositiveFeedback
                 WebAppConfHelp: !Ref WebAppConfHelp
+                WebAppConfCname: !Ref WebAppConfCname
+                WebAppAcmCertificateArn: !Ref WebAppAcmCertificateArn
+                WebAppWafAclArn: !Ref WebAppWafAclArn
                 HideButtonMessageBubble: !Ref HideButtonMessageBubble
                 ShouldEnableLiveChat: !Ref ShouldEnableLiveChat
                 ConnectContactFlowId: !Ref ConnectContactFlowId
@@ -557,7 +583,7 @@ Resources:
                 CodeBuildProjectName: !Ref CodeBuildName
                 CognitoUserPool: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolId
                 CognitoUserPoolClient: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolClientId
-                Timestamp: 1677532224
+                Timestamp: 1678465363
 
 Outputs:
     BotName:

--- a/templates/master.yaml
+++ b/templates/master.yaml
@@ -326,6 +326,26 @@ Parameters:
         Default: Order Flowers
         Description: Title displayed in the chatbot UI toolbar
 
+    WebAppConfCname:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a single CNAME to be defined and used as an alias to
+            the cloudfront distribution that is created by this template. If a CNAME is provided, a
+            WebAppAcmCertificateArn must also be provided.
+
+    WebAppAcmCertificateArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AcmCertificateArn to be provided for use in the Cloudfront
+            distribution created by this template. if a AcmCertificateArn is provided, a WebAppConfCname must also
+            be provided.
+
+    WebAppWafAclArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AWS WAF web ACL to be specified in ARN formation. This supports
+            AWS WAF V2.
+
     HideButtonMessageBubble:
         Type: String
         Default: false
@@ -530,6 +550,9 @@ Metadata:
                   - WebAppConfNegativeFeedback
                   - WebAppConfPositiveFeedback
                   - WebAppConfHelp
+                  - WebAppAcmCertificateArn
+                  - WebAppConfCname
+                  - WebAppWafAclArn
                   - HideButtonMessageBubble
                   - MessageMenu
                   - BackButton
@@ -632,6 +655,9 @@ Resources:
                 WebAppConfNegativeFeedback: !Ref WebAppConfNegativeFeedback
                 WebAppConfPositiveFeedback: !Ref WebAppConfPositiveFeedback
                 WebAppConfHelp: !Ref WebAppConfHelp
+                WebAppConfCname: !Ref WebAppConfCname
+                WebAppAcmCertificateArn: !Ref WebAppAcmCertificateArn
+                WebAppWafAclArn: !Ref WebAppWafAclArn
                 HideButtonMessageBubble: !Ref HideButtonMessageBubble
                 MessageMenu: !Ref MessageMenu
                 BackButton: !Ref BackButton
@@ -675,7 +701,7 @@ Resources:
                 ConnectStartLiveChatIcon: !Ref ConnectStartLiveChatIcon
                 ConnectEndLiveChatLabel: !Ref ConnectEndLiveChatLabel
                 ConnectEndLiveChatIcon: !Ref ConnectEndLiveChatIcon
-                Timestamp: 1677532224
+                Timestamp: 1678465363
 
     CognitoIdentityPoolConfig:
         Type: AWS::CloudFormation::Stack
@@ -689,7 +715,7 @@ Resources:
                 CodeBuildProjectName: !GetAtt CodeBuildDeploy.Outputs.CodeBuildProject
                 CognitoUserPool: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolId
                 CognitoUserPoolClient: !GetAtt CognitoIdentityPool.Outputs.CognitoUserPoolClientId
-                Timestamp: 1677532224
+                Timestamp: 1678465363
 
 Outputs:
     BotName:

--- a/templates/pipeline.yaml
+++ b/templates/pipeline.yaml
@@ -200,6 +200,26 @@ Parameters:
             When pressed the button will send the entered string to the bot as a help message.  If left empty
             the help button will be disabled.
 
+    WebAppConfCname:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a single CNAME to be defined and used as an alias to
+            the cloudfront distribution that is created by this template. If a CNAME is provided, a
+            WebAppAcmCertificateArn must also be provided.
+
+    WebAppAcmCertificateArn:
+        Type: String
+        Default: ""
+        Description: This optional parameter allows a AcmCertificateArn to be provided for use in the Cloudfront
+            distribution created by this template. if a AcmCertificateArn is provided, a WebAppConfCname must also
+            be provided.
+
+    WebAppWafAclArn:
+      Type: String
+      Default: ""
+      Description: This optional parameter allows a AWS WAF web ACL to be specified in ARN formation. This supports
+        AWS WAF V2.
+
     ShouldEnableLiveChat:
       Type: String
       Default: false
@@ -305,6 +325,8 @@ Conditions:
     NeedsParentOrigin: !Equals [!Ref ParentOrigin, '']
     ShouldCleanupBuckets: !Equals [!Ref CleanupBuckets, true]
     EnableLiveChat: !Equals [!Ref ShouldEnableLiveChat, true]
+    UseDefaultCloudfrontUrl: !Or [ !Equals [!Ref WebAppConfCname, ''], !Equals [!Ref WebAppAcmCertificateArn, ''] ]
+    ShouldNotSpecifyWafAcl: !Equals [!Ref WebAppWafAclArn, '']
 
 Resources:
     # Bucket where S3 access logs are stored
@@ -472,8 +494,24 @@ Resources:
               OriginRequestPolicyId: "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
               ViewerProtocolPolicy: redirect-to-https
               ResponseHeadersPolicyId: !GetAtt LexWebUIResponseHeaderPolicy.Id
+            Aliases:
+              !If
+              - UseDefaultCloudfrontUrl
+              - !Ref AWS::NoValue
+              - [ !Ref WebAppConfCname ]
             ViewerCertificate:
-              CloudFrontDefaultCertificate: true
+              !If
+              - UseDefaultCloudfrontUrl
+              - CloudFrontDefaultCertificate: true
+              - AcmCertificateArn: !Ref WebAppAcmCertificateArn
+                CloudFrontDefaultCertificate: false
+                MinimumProtocolVersion: TLSv1.2_2018
+                SslSupportMethod: sni-only
+            WebACLId:
+              !If
+              - ShouldNotSpecifyWafAcl
+              - !Ref AWS::NoValue
+              - !Ref WebAppWafAclArn
             HttpVersion: http2
             IPV6Enabled: true
 


### PR DESCRIPTION
Add the ability to configure a precreated CNAME, ACM Certificate, and WAFV2 ACL via template parameters. If the values are left empty default cloudfront distribution url and certificates is used. If a WAFV2 ACl is not supplied then no WAF Acl is configured for use by cloudfront.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
