### PR TITLE
Clean up date logic & bump vuetify dependencies

### DIFF
--- a/src/lex-web-ui-loader/js/defaults/dependencies.js
+++ b/src/lex-web-ui-loader/js/defaults/dependencies.js
@@ -37,7 +37,7 @@ export const dependenciesFullPage = {
     },
     {
       name: 'Vuetify',
-      url: 'https://unpkg.com/vuetify@0.17.7/dist/vuetify.js',
+      url: 'https://unpkg.com/vuetify@1.5.0/dist/vuetify.js',
       canUseMin: true,
     },
     {
@@ -53,7 +53,7 @@ export const dependenciesFullPage = {
     },
     {
       name: 'vuetify',
-      url: 'https://unpkg.com/vuetify@0.17.7/dist/vuetify.css',
+      url: 'https://unpkg.com/vuetify@1.5.0/dist/vuetify.css',
       canUseMin: true,
     },
     {


### PR DESCRIPTION
This PR cleans up an issue that occurred when trying to render the DateTime picker with multiple language locales in the bot, also clean up the logic a bit to remove complexity and add readability.

Also addresses an issue where certain parts of the ListPicker were not rendering because the loader dependencies were very old and certain veutify components were not supported