### PR TITLE
persistent live chat

### DIFF
--- a/lex-web-ui/src/store/live-chat-handlers.js
+++ b/lex-web-ui/src/store/live-chat-handlers.js
@@ -42,6 +42,10 @@ export const initLiveChatHandlers = (context, session) => {
     //   type: 'agent',
     //   text: 'Live Chat Connection Established',
     // });
+    if (context.state.liveChat.reconnectToActiveChat){
+      context.commit('setIsLiveChatProcessing', false);
+      context.dispatch('liveChatAgentJoined');
+    }
   });
 
   session.onMessage((event) => {
@@ -144,17 +148,45 @@ export const initLiveChatHandlers = (context, session) => {
   });
 
   session.onTyping((typingEvent) => {
+    console.info('typingEvent: ', typingEvent);
     if (typingEvent.data.ParticipantRole === 'AGENT') {
       console.info('Agent is typing ');
       context.dispatch('agentIsTyping');
     }
   });
 
+  /*
   session.onConnectionBroken((data) => {
     console.info('Connection broken', data);
     context.dispatch('liveChatSessionReconnectRequest');
   });
+ 
+  session.onEnded(event => {
+    const { chatDetails, data } = event;
+    console.info('Connection has ended.', event);
+  });
+  
+  session.onParticipantIdle(event => {
+    const { chatDetails, data } = event;
+    console.info('participant.idle event', event);
+  });
 
+  session.onParticipantReturned(event => {
+    const { chatDetails, data } = event;
+    console.info('onParticipantReturned event', event);
+  });
+
+  session.onAutoDisconnection(event => {
+    const { chatDetails, data } = event;
+    console.info('onAutoDisconnection event', event);
+  });
+  
+  session.onConnectionLost(event => {
+    const { chatDetails, data } = event;
+    console.info('onConnectionLost event', event);
+  });
+  */
+ 
   /*
   NOT WORKING
   session.onEnded((data) => {

--- a/lex-web-ui/src/store/mutations.js
+++ b/lex-web-ui/src/store/mutations.js
@@ -405,6 +405,45 @@ export default {
     state.liveChat.isProcessing = bool;
   },
 
+  setLiveChatUtteranceSent(state) {
+    state.liveChatUtteranceSent = true;
+  },
+
+  setParticipantToken(state, participantToken) {
+    if (typeof participantToken !== 'string') {
+      console.error('setParticipantToken is not valid', participantToken);
+      return;
+    }
+    state.liveChat.participantToken = participantToken;
+  },
+
+  setParticipantId(state, participantId) {
+    if (typeof participantId !== 'string') {
+      console.error('setParticipantId is not valid', participantId);
+      return;
+    }
+    state.liveChat.participantId = participantId;
+  },
+
+  setContactId(state, contactId) {
+    if (typeof contactId !== 'string') {
+      console.error('setContactId is not valid', contactId);
+      return;
+    }
+    state.liveChat.contactId = contactId;
+  },
+
+
+
+
+  setReconnectToActiveChat(state, bool) {
+    if (typeof bool !== 'boolean'){
+      console.error('setReconnectToActiveChat status not boolean', bool);
+      return;
+    }
+    state.liveChat.reconnectToActiveChat = bool;
+  },
+
   setLiveChatUserName(state, name) {
     if (typeof name !== 'string') {
       console.error('setLiveChatUserName is not vaild', name);

--- a/lex-web-ui/src/store/state.js
+++ b/lex-web-ui/src/store/state.js
@@ -60,6 +60,10 @@ export default {
     isProcessing: false,
     status: liveChatStatus.DISCONNECTED,
     message: '',
+    participantToken: '',
+    participantId: '',
+    contactId: '',
+    reconnectToActiveChat: false,
   },
   messages: [],
   utteranceStack: [],
@@ -95,6 +99,7 @@ export default {
     !!config.ui.messageSentSFX && !!config.ui.messageReceivedSFX) : false,
   isUiMinimized: false, // when running embedded, is the iframe minimized?
   initialUtteranceSent: false, // has the initial utterance already been sent
+  liveChatUtteranceSent: false, // has the live chat utterance already been sent
   isEnableLogin: false, // true when a login/logout menu should be displayed
   isForceLogin: false, // true when a login/logout menu should be displayed
   isLoggedIn: false, // when running with login/logout enabled

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -363,7 +363,7 @@ Parameters:
 
     SaveHistory:
         Type: String
-        Default: false
+        Default: true
         AllowedValues:
           - true
           - false


### PR DESCRIPTION
The following pull request is to allow lex-web-ui to maintain the connection
to Amazon connect chat session across browser refreshes.

*Issue # None

*Description of changes:*
   Following the suggestion of this readme:
   https://github.com/amazon-connect/amazon-connect-chatjs#handle-browser-refresh
   I added several state variables:
    participantToken: '',
    participantId: '',
    contactId: '',
    reconnectToActiveChat

    To see if a previous live chat session exists.  If so then pass in the saved state variables into:
    connect.ChatSession.create

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
