### PR TITLE
fix: wrong reference to `isPostTextRetry`

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -589,7 +589,7 @@ export default {
         if (context.state.lex.dialogState === 'Fulfilled') {
           context.dispatch('reInitBot');
         }
-        if (context.state.isPostTextRetry) {
+        if (context.state.lex.isPostTextRetry) {
           context.commit('setPostTextRetry', false);
         }
       })


### PR DESCRIPTION
*Description of changes:*

In `lex-web-ui/src/store/actions.js`, there is a reference to `context.state.isPostTextRetry` but `isPostTextRetry` should be accessed via `context.state.lex.isPostTextRetry` instead.
In the current state, the block `if (context.state.isPostTextRetry) {` is never accessed because `context.state.isPostTextRetry` is undefined.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Please modify PR to your convenience if needed.
Thanks!
