### PR TITLE
Bug/build config syntax

### DIFF
--- a/lex-web-ui/vue.config.js
+++ b/lex-web-ui/vue.config.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 // eslint-disable-next-line import/no-extraneous-dependencies
 const webpack = require('webpack');
-const NodePolyfillPlugin = require('node-polyfill-webpack-plugin'); 
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 const distDir = path.resolve(__dirname, 'dist');
 const assetsDir = path.resolve(__dirname, 'src/assets');
@@ -85,7 +85,7 @@ function chainWebpackCommon(config, destDir) {
       return args;
     })
     .end();
-  
+
   config.devtool(buildType.isProd ? false : 'source-map');
 
   chainWebpackWorker(config, destDir);
@@ -97,7 +97,7 @@ function chainWebpackCommon(config, destDir) {
       return args;
     })
     .end();
-  
+
   config.plugin('NodePolyfillPlugin').use(new NodePolyfillPlugin());
 }
 
@@ -210,7 +210,7 @@ function chainWebpackApp(config, destDir = '') {
     .tap((args) => {
       // unshift to have lower precedence
       // from the default vue cli `public` rule
-      patterns = Array.from(args[0]);
+      const patterns = Array.from(args[0]);
       patterns.unshift(
         // favicon.png
         {
@@ -223,7 +223,7 @@ function chainWebpackApp(config, destDir = '') {
           to: `${distDir}/logo.png`,
         },
       );
-      args[0] = { patterns: patterns };
+      args[0] = { patterns };
       return args;
     });
 }

--- a/lex-web-ui/vue.config.js
+++ b/lex-web-ui/vue.config.js
@@ -223,6 +223,7 @@ function chainWebpackApp(config, destDir = '') {
           to: `${distDir}/logo.png`,
         },
       );
+      // eslint-disable-next-line no-param-reassign
       args[0] = { patterns };
       return args;
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,19 +74,32 @@ module.exports = (env) => {
     },
     devtool: (isProd) ? 'source-map' : 'cheap-module-source-map',
     devServer: {
-      contentBase: [
-        path.join(__dirname, 'src/config'),
-        path.join(__dirname, 'src/website'),
-        distDir,
+      static: [
+        {
+          directory: path.join(__dirname, 'src/config'),
+        },
+        {
+          directory: path.join(__dirname, 'src/website'),
+        },
+        {
+          directory: distDir,
+        },
       ],
-      clientLogLevel: 'warning',
+      client: {
+        logging: 'warn',
+        overlay: {
+          errors: true,
+          warnings: false,
+          runtimeErrors: true,
+
+        },
+      },
       hot: true,
       port: devServerPort,
-      overlay: { warnings: false, errors: true },
-      stats: 'errors-only',
     },
     stats: {
       modules: false,
+      logging: 'error',
     },
     plugins: [
       new webpack.ProvidePlugin({


### PR DESCRIPTION
*Description of changes:*
- ##### Refactored/dupe of https://github.com/aws-samples/aws-lex-web-ui/pull/559

This PR addresses naming an unnamed var in `vue.config.js` that was blocking `npm run build-dist` in `/lex-web-ui`. It also brings `webpack.config.js` into v5 syntax in order to `npm run dev` without the following schema error on `devServer`:

```shell
❯ npm run dev

> aws-lex-web-ui@0.20.0 dev
> webpack-dev-server --mode development  --hot

[webpack-cli] Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'stats'. These properties are valid:
   object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, http2?, https?, ipc?, liveReload?, magicHtml?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, port?, proxy?, server?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? }
~/aws-lex-web-ui on master !23 ❯        
```

*Refs:*
- _[webpack@5#devServer](https://webpack.js.org/configuration/dev-server/)_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
