### PR TITLE
Feature/remove cf csp

### DIFF
--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -658,9 +658,6 @@ Resources:
               IncludeSubdomains: True
               Preload: False
               AccessControlMaxAgeSec: 47304000
-            ContentSecurityPolicy:
-              Override: false
-              ContentSecurityPolicy: !Sub "img-src 'self' ${ParentOrigin} ${MarkdownSupportDomains}; frame-src 'self' ${ParentOrigin} ${MarkdownSupportDomains};"
 
     LexWebUiDistribution:
         Type: AWS::CloudFront::Distribution

--- a/templates/master.yaml
+++ b/templates/master.yaml
@@ -238,12 +238,6 @@ Parameters:
             scripting (XSS) attack from insecure Bots. Make sure you trust the Bot being used
             by the LexWebUi.
 
-    MarkdownSupportDomains:
-        Type: String
-        Description: >
-            If enabling Markdown support, provide a space-seperated list of allowable sources 
-            for content (images/video). Any domain not listed here will be blocked by Content Security Policy.
-
     ReInitSessionAttributesOnRestart:
         Type: String
         Default: false
@@ -613,7 +607,6 @@ Metadata:
                   - ForceCognitoLogin
                   - AllowedSignUpEmailDomain
                   - EnableMarkdownSupport
-                  - MarkdownSupportDomains
                   - ReInitSessionAttributesOnRestart
                   - ShowResponseCardTitle
                   - SaveHistory
@@ -773,7 +766,6 @@ Resources:
                 ShouldForceCognitoLogin: !Ref ForceCognitoLogin
                 ReInitSessionAttributesOnRestart: !Ref ReInitSessionAttributesOnRestart
                 EnableMarkdownSupport: !Ref EnableMarkdownSupport
-                MarkdownSupportDomains: !Ref MarkdownSupportDomains
                 ShouldLoadIframeMinimized: !Ref ShouldLoadIframeMinimized
                 ShowResponseCardTitle: !Ref ShowResponseCardTitle
                 CognitoAppUserPoolClientId:


### PR DESCRIPTION
Removes the CloudFront CSP restrictions as they were causing compatibility issues with Markdown users and Title/Avatar images.