### PR TITLE
Fix/config: bundler and loader syntax variety

### DIFF
--- a/lex-web-ui/vue.config.js
+++ b/lex-web-ui/vue.config.js
@@ -210,8 +210,7 @@ function chainWebpackApp(config, destDir = '') {
     .tap((args) => {
       // unshift to have lower precedence
       // from the default vue cli `public` rule
-      const patterns = Array.from(args[0]);
-      patterns.unshift(
+      args[0].patterns.unshift(
         // favicon.png
         {
           from: getAssetPath(favIconPath, flowerLogoPath),
@@ -223,8 +222,6 @@ function chainWebpackApp(config, destDir = '') {
           to: `${distDir}/logo.png`,
         },
       );
-      // eslint-disable-next-line no-param-reassign
-      args[0] = { patterns };
       return args;
     });
 }

--- a/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
+++ b/src/lex-web-ui-loader/js/lib/iframe-component-loader.js
@@ -60,14 +60,14 @@ export class IframeComponentLoader {
     // assign the iframeOrigin if not found in config
     if (!(('iframeOrigin' in iframeConfig) && iframeConfig.iframeOrigin)) {
       this.config.iframe.iframeOrigin =
-        this.config.parentOrigin || window.location.origin;
+        this.config.ui.parentOrigin || window.location.origin;
     }
     if (iframeConfig.shouldLoadIframeMinimized === undefined) {
       this.config.iframe.shouldLoadIframeMinimized = true;
     }
     // assign parentOrigin if not found in config
-    if (!(this.config.parentOrigin)) {
-      this.config.parentOrigin =
+    if (!(this.config.ui.parentOrigin)) {
+      this.config.ui.parentOrigin =
        this.config.iframe.iframeOrigin || window.location.origin;
     }
     // validate config
@@ -89,7 +89,7 @@ export class IframeComponentLoader {
    * Validate that the config has the expected structure
    */
   static validateConfig(config) {
-    const { iframe: iframeConfig } = config;
+    const { iframe: iframeConfig, ui: uiConfig } = config;
     if (!iframeConfig) {
       console.error('missing iframe config field');
       return false;
@@ -102,7 +102,7 @@ export class IframeComponentLoader {
       console.error('missing iframeSrcPath config field');
       return false;
     }
-    if (!('parentOrigin' in config && config.parentOrigin)) {
+    if (!('parentOrigin' in uiConfig && uiConfig.parentOrigin)) {
       console.error('missing parentOrigin config field');
       return false;
     }
@@ -481,8 +481,8 @@ export class IframeComponentLoader {
           if (this.config.ui.enableLogin && this.config.ui.enableLogin === true) {
             const auth = getAuth(this.generateConfigObj());
             const session = auth.getSignInUserSession();
+            const tokens = {};
             if (session.isValid()) {
-              const tokens = {};
               tokens.idtokenjwt = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}idtokenjwt`);
               tokens.accesstokenjwt = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}accesstokenjwt`);
               tokens.refreshtoken = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}refreshtoken`);
@@ -502,7 +502,6 @@ export class IframeComponentLoader {
               if (refToken) {
                 refreshLogin(this.generateConfigObj(), refToken, (refSession) => {
                   if (refSession.isValid()) {
-                    const tokens = {};
                     tokens.idtokenjwt = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}idtokenjwt`);
                     tokens.accesstokenjwt = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}accesstokenjwt`);
                     tokens.refreshtoken = localStorage.getItem(`${this.config.cognito.appUserPoolClientId}refreshtoken`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,8 +158,8 @@ module.exports = (env) => {
             },
             // copy lex-web-ui library
             {
-              from: getAssetPath(path.join(basePath, 'lex-web-ui/dist/bundle/*.*'), assetsDir),
-              to: path.resolve(distDir, '[name][ext]'),
+              from: getAssetPath(path.join(basePath, 'lex-web-ui/dist/bundle/**/*'), assetsDir),
+              to: path.resolve(distDir, '[path][name][ext]'),
               globOptions: {
                 ignore: [
                   "**/*.html",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,16 +4,22 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const eslintFormatterFriendly = require('eslint-formatter-friendly');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const fs = require('fs');
 
+function getAssetPath(filePath, defaultPath) {
+  const fileExists = fs.existsSync(filePath);
+  return fileExists ? filePath : defaultPath;
+}
 
 const VERSION = require('./package.json').version;
 
 const basePath = __dirname;
 const distDir = path.join(basePath, 'dist');
+const assetsDir = path.resolve(__dirname, 'lex-web-ui/dist/bundle');
 const devServerPort = (process.env.PORT) ? Number(process.env.PORT) : 8000;
 
 module.exports = (env) => {
-  const isProd = env.production;
+  const isProd =  (env.production === true);
 
   return {
     mode: (isProd) ? 'production' : 'development',
@@ -73,6 +79,9 @@ module.exports = (env) => {
       ],
     },
     devtool: (isProd) ? 'source-map' : 'cheap-module-source-map',
+    performance: {
+      hints: false,
+    },
     devServer: {
       static: [
         {
@@ -100,6 +109,9 @@ module.exports = (env) => {
     stats: {
       modules: false,
       logging: 'error',
+    },
+    optimization: {
+      minimize: false,
     },
     plugins: [
       new webpack.ProvidePlugin({
@@ -146,13 +158,15 @@ module.exports = (env) => {
             },
             // copy lex-web-ui library
             {
-              from: path.join(basePath, 'lex-web-ui/dist/bundle/lex-web-ui.*'),
-              to: distDir,
+              from: getAssetPath(path.join(basePath, 'lex-web-ui/dist/bundle/*.*'), assetsDir),
+              to: path.resolve(distDir, '[name][ext]'),
+              globOptions: {
+                ignore: [
+                  "**/*.html",
+                  "**.*.txt",
+                ],
+              },
             },
-            {
-              from: path.join(basePath, 'lex-web-ui/dist/bundle/wav-worker.*'),
-              to: distDir,
-            }
           ]
         }
       ),


### PR DESCRIPTION
*Description of changes:*

This PR picks up some red errors when running  `npm run build` at root, `npm run build-dist` at child, and `npm run dev` at either, which exposed the anomalies via stack trace in debug/dev mode.

1.  Define `isProd`  to correctly map `env`

```sh
> aws-lex-web-ui@0.20.2 build-dev
> webpack --mode development

env { WEBPACK_BUNDLE: true, WEBPACK_BUILD: true }
(env.production === true) false
env.production undefined
```

2.  Refactor/fix [copy-webpack-plugin](https://webpack.js.org/plugins/copy-webpack-plugin/) v5 signature in`webpack.config.js` Note: `optimization.minimize: false` removes License.txt outputs [`file].LICENSE.txt[query]`](https://webpack.js.org/plugins/terser-webpack-plugin/#filename) without [plugging Terser](https://github.com/webpack/webpack/issues/12506).

3.  Fix array method in copy plugin at `vue.config.js`

4.  Fix incorrect object paths to `parentOrigin` through `ui.parentOrigin`  in `iframeComponentLoader` previously hanging loosely at `config` during the loader's config/merge options variety. (Consequence to options passed at `load` not fully tested). An undefined `tokens` variable was also moved to the outer scope.

<div align="center"><img width="181" style:="center" alt="Screen Shot 2023-12-12 at 9 58 27 PM" src="https://github.com/aws-samples/aws-lex-web-ui/assets/61286823/0af78b4c-c30c-49b1-8ed2-7bdd21966481"></div>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
