### PR TITLE
Updates for more flexible streaming options

### DIFF
--- a/config/base.env.js
+++ b/config/base.env.js
@@ -40,6 +40,7 @@ module.exports = {
     retryCountPostTextTimeout: process.env.BOT_RETRY_COUNT_POST_TEXT_TIMEOUT,
     allowStreamingResponses: (process.env.ALLOW_STREAMING_RESPONSES === undefined) ? undefined : (process.env.ALLOW_STREAMING_RESPONSES === 'true') ? true : false,
     streamingWebSocketEndpoint: process.env.STREAMING_WEB_SOCKET_ENDPOINT,
+    streamingDynamoDbTable: process.env.STREAMING_DYNAMO_TABLE,
   },
   ui: {
     parentOrigin: process.env.PARENT_ORIGIN,

--- a/lex-web-ui/.browserslistrc
+++ b/lex-web-ui/.browserslistrc
@@ -1,3 +1,1 @@
-> 1%
-last 2 versions
-not dead
+defaults and fully supports es6-module

--- a/lex-web-ui/package.json
+++ b/lex-web-ui/package.json
@@ -53,8 +53,8 @@
     "worker-loader": "^3.0.8"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=7.8.0"
+    "node": ">=18.0.0",
+    "npm": ">=10.0.0"
   },
   "overrides": {
     "postcss": "8.4.32"

--- a/lex-web-ui/src/components/InputContainer.vue
+++ b/lex-web-ui/src/components/InputContainer.vue
@@ -264,6 +264,16 @@ export default {
           }).toString();
       }
 
+      // If streaming, send session attributes for streaming
+      if(this.$store.state.config.lex.allowStreamingResponses){
+        // Replace with an HTTP endpoint for the fullfilment Lambda
+        const streamingEndpoint = this.$store.state.config.lex.streamingWebSocketEndpoint.replace('wss://', 'https://');
+        this.$store.dispatch('setSessionAttribute', 
+          { key: 'streamingEndpoint', value: streamingEndpoint });
+        this.$store.dispatch('setSessionAttribute', 
+          { key: 'streamingDynamoDbTable', value: this.$store.state.config.lex.streamingDynamoDbTable });
+      }
+
       return this.$store.dispatch('postTextMessage', message)
         .then(() => {
           this.textInput = '';

--- a/lex-web-ui/src/components/Message.vue
+++ b/lex-web-ui/src/components/Message.vue
@@ -28,14 +28,7 @@
                 <message-text
                   :message="message"
                   v-if="'text' in message && message.text !== null && message.text.length && !shouldDisplayInteractiveMessage"
-                ></message-text>
-                <v-icon
-                  v-if="message.type === 'bot' &&  message.id !== $store.state.messages[0].id"
-                  class="copy-icon"
-                  @click="copyMessageToClipboard(message.text)"
-                >
-                content_copy
-              </v-icon>
+                ></message-text>                
                 <div
                   v-if="shouldDisplayInteractiveMessage && message.interactiveMessage.templateType == 'ListPicker'">
                   <v-card-title primary-title>
@@ -97,6 +90,13 @@
                   </v-datetime-picker>
                   <v-btn v-on:click="sendDateTime(datetime)" variant="flat">Confirm</v-btn>
                 </div>
+                <v-icon
+                  v-if="message.type === 'bot' &&  message.id !== $store.state.messages[0].id && showCopyIcon"
+                  class="copy-icon"
+                  @click="copyMessageToClipboard(message.text)"
+                >
+                  content_copy
+                </v-icon>
                 <div
                   v-if="message.id === this.$store.state.messages.length - 1 && isLastMessageFeedback && message.type === 'bot' && botDialogState && showDialogFeedback"
                   class="feedback-state"
@@ -294,6 +294,9 @@ export default {
     },
     showDialogStateIcon() {
       return this.$store.state.config.ui.showDialogStateIcon;
+    },
+    showCopyIcon() {
+      return this.$store.state.config.ui.showCopyIcon;
     },
     showMessageMenu() {
       return this.$store.state.config.ui.messageMenu;
@@ -628,6 +631,15 @@ export default {
 
 .feedback-icons-negative:hover{
   color: red;
+}
+
+.copy-icon {
+  display: inline-flex;
+  align-self: center;
+}
+
+.copy-icon:hover{
+  color: grey;
 }
 
 .response-card {

--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -140,8 +140,11 @@ const configDefault = {
     // allows the Lex bot to use streaming responses for integration with LLMs or other streaming protocols
     allowStreamingResponses: false,
 
-     // web socket endpoint for streaming
+    // web socket endpoint for streaming
      streamingWebSocketEndpoint: '',
+
+    // dynamo DB table for streaming
+    streamingDynamoDbTable: '',
   },
 
   polly: {
@@ -226,6 +229,9 @@ const configDefault = {
 
     // Show the diaglog state icon, check or alert, in the text bubble
     showDialogStateIcon: true,
+
+    // Give the ability for users to copy the text from the bot
+    showCopyIcon: false,
 
     // Hide the message bubble on a response card button press
     hideButtonMessageBubble: false,

--- a/lex-web-ui/src/lex-web-ui.js
+++ b/lex-web-ui/src/lex-web-ui.js
@@ -31,6 +31,7 @@ import VuexStore from '@/store';
 
 import { config as defaultConfig, mergeConfig } from '@/config';
 import { createApp, defineAsyncComponent } from 'vue';
+import { createAppDev } from 'vue/dist/vue.esm-bundler.js';
 import { aliases, md } from 'vuetify/iconsets/md';
 import { createStore } from 'vuex';
 

--- a/package.json
+++ b/package.json
@@ -67,12 +67,10 @@
     "webpack-dev-server": "^4.15.1"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=7.8.0"
+    "node": ">=18.0.0",
+    "npm": ">=10.0.0"
   },
   "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "ie >= 11"
+    "defaults and fully supports es6-module"
   ]
 }

--- a/src/config/default-lex-web-ui-loader-config.json
+++ b/src/config/default-lex-web-ui-loader-config.json
@@ -25,7 +25,8 @@
     "v2BotAliasId": "",
     "v2BotLocaleId": "",
     "allowStreamingResponses": false,
-    "streamingWebSocketEndpoint": ""
+    "streamingWebSocketEndpoint": "",
+    "streamingDynamoDbTable": ""
   },
   "ui": {
     "parentOrigin": "http://localhost:8000",

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -936,6 +936,8 @@ Resources:
                       Value: !Ref AllowStreamingResponses
                     - Name: STREAMING_WEB_SOCKET_ENDPOINT
                       Value: !If [EnableStreaming, !Sub "wss://${StreamingSupport.Outputs.WebSocketId}.execute-api.${AWS::Region}.amazonaws.com/Prod", ""]
+                    - Name: STREAMING_DYNAMO_TABLE
+                      Value: !If [EnableStreaming, !Sub "${StreamingSupport.Outputs.DynamoTableName}", ""]                    
                     - Name: ENABLE_UPLOAD
                       Value: !Ref ShouldEnableUpload
                     - Name: UPLOAD_BUCKET_NAME

--- a/templates/streaming-support.yaml
+++ b/templates/streaming-support.yaml
@@ -174,7 +174,7 @@ Resources:
   ApiKey:
     Type: 'AWS::ApiGateway::ApiKey'
     Properties:
-      Name: StreamingApiKey
+      Name: !Join ["-", [!Ref ParentStackName, "StreamingApiKey"]]
       Enabled: 'true'
   
   UsagePlanKey:


### PR DESCRIPTION
This update is designed to make streaming more flexible in scenarios where the bot is handling both streaming and non-streaming conversations. Turning streaming on at the Web UI will now trigger session attributes containing the dynamo table and API Gateway endpoint information, so fulfillment Lambdas can look for those parameters and decide whether the response needs to be streamed.

Other small changes
- Bring the Web UI up to speed on Node/NPM versions 
- Change the browser targets for webpack.
- Make the copy function/icon a toggle controlled by a config property and center it to align with the feedback buttons.