### PR TITLE
streaming endpoint support for qnabot

### DIFF
--- a/lex-web-ui/src/config/index.js
+++ b/lex-web-ui/src/config/index.js
@@ -141,7 +141,7 @@ const configDefault = {
     allowStreamingResponses: false,
 
     // web socket endpoint for streaming
-     streamingWebSocketEndpoint: '',
+    streamingWebSocketEndpoint: '',
 
     // dynamo DB table for streaming
     streamingDynamoDbTable: '',

--- a/templates/codebuild-deploy.yaml
+++ b/templates/codebuild-deploy.yaml
@@ -519,7 +519,7 @@ Parameters:
         Description: >
          This is an optional parameter, when set to an image URL that is accessible by the application it will 
          display on the left of all bot messages
-    
+         
     AllowStreamingResponses:
         Type: String
         Default: false
@@ -529,7 +529,19 @@ Parameters:
         Description: >
             If set to True, a websocket API Gateway will be established and messages will be sent to this web socket
             in addition to the Lex bot directly.
-    
+
+    StreamingWebSocketEndpoint:
+        Type: String
+        Default: ''
+        Description: >
+            If not using the Web socket endpoint created via AllowStreamingResponses, you can optionally specify an alternative streaming endpoint here
+
+    StreamingDynamoDbTable:
+        Type: String
+        Default: ''
+        Description: >
+            If not using the DynamoDB table through Lex Web UI, you can optionally specify an alternative table for streaming purposes here
+
     ShouldEnableUpload:
         Type: String
         Default: false
@@ -563,6 +575,8 @@ Conditions:
     UseDefaultCloudfrontUrl: !Or [ !Equals [!Ref WebAppConfCname, ''], !Equals [!Ref WebAppAcmCertificateArn, ''] ]
     ShouldNotSpecifyWafAcl: !Equals [!Ref WebAppWafAclArn, '']
     EnableStreaming: !Equals [!Ref AllowStreamingResponses, true]
+    HasStreamingWebSocketEndpoint: !Not [!Equals [!Ref StreamingWebSocketEndpoint, ""]]
+    HasStreamingDynamoDbTable: !Not [!Equals [!Ref StreamingDynamoDbTable, ""]]
     EnableUpload: !Equals [!Ref ShouldEnableUpload, true]
     NeedsVpc:  !And [ !Not [ !Equals [!Ref VpcSubnetId, ''] ], !Not [ !Equals [!Ref VpcSecurityGroupId, ''] ] ] 
 
@@ -950,9 +964,9 @@ Resources:
                     - Name: ALLOW_STREAMING_RESPONSES
                       Value: !Ref AllowStreamingResponses
                     - Name: STREAMING_WEB_SOCKET_ENDPOINT
-                      Value: !If [EnableStreaming, !Sub "wss://${StreamingSupport.Outputs.WebSocketId}.execute-api.${AWS::Region}.amazonaws.com/Prod", ""]
+                      Value: !If [EnableStreaming, !If [HasStreamingWebSocketEndpoint, !Ref StreamingWebSocketEndpoint, !Sub "wss://${StreamingSupport.Outputs.WebSocketId}.execute-api.${AWS::Region}.amazonaws.com/Prod"], ""]
                     - Name: STREAMING_DYNAMO_TABLE
-                      Value: !If [EnableStreaming, !Sub "${StreamingSupport.Outputs.DynamoTableName}", ""]                    
+                      Value: !If [EnableStreaming, !If [HasStreamingDynamoDbTable, !Ref StreamingDynamoDbTable, !Sub "${StreamingSupport.Outputs.DynamoTableName}"], ""]
                     - Name: ENABLE_UPLOAD
                       Value: !Ref ShouldEnableUpload
                     - Name: UPLOAD_BUCKET_NAME
@@ -1041,6 +1055,8 @@ Resources:
             TitleLogoImgUrl: !Ref TitleLogoImgUrl
             BotAvatarImgUrl: !Ref BotAvatarImgUrl
             AllowStreamingResponses: !Ref AllowStreamingResponses
+            StreamingWebSocketEndpoint: !Ref StreamingWebSocketEndpoint
+            StreamingDynamoDbTable: !Ref StreamingDynamoDbTable
             ShouldEnableUpload: !Ref ShouldEnableUpload
             UploadBucket: !Ref UploadBucket
             Timestamp: !Ref Timestamp

--- a/templates/master.yaml
+++ b/templates/master.yaml
@@ -557,6 +557,18 @@ Parameters:
             If set to True, a websocket API Gateway will be established and messages will be sent to this web socket
             in addition to the Lex bot directly. More details on how to configure your bot for streaming intereactions
             can be found here: https://github.com/zhengjie28/lex-web-ui-websocket
+
+    StreamingWebSocketEndpoint:
+        Type: String
+        Default: ''
+        Description: >
+            If not using the Web socket endpoint created via AllowStreamingResponses, you can optionally specify an alternative streaming endpoint here
+            
+    StreamingDynamoDbTable:
+        Type: String
+        Default: ''
+        Description: >
+            If not using the DynamoDB table through Lex Web UI, you can optionally specify an alternative table for streaming purposes here
     
     ShouldEnableUpload:
         Type: String
@@ -650,6 +662,8 @@ Metadata:
                   - retryOnLexPostTextTimeout
                   - retryCountPostTextTimeout
                   - AllowStreamingResponses
+                  - StreamingWebSocketEndpoint
+                  - StreamingDynamoDbTable
                   - ShouldEnableUpload
                   - UploadBucket
             - Label:
@@ -783,6 +797,8 @@ Resources:
                 CodeBuildName: !Ref CodeBuildName
                 SourceBucket: !Ref BootstrapBucket
                 SourcePrefix: !Ref BootstrapPrefix
+                StreamingWebSocketEndpoint: !Ref StreamingWebSocketEndpoint
+                StreamingDynamoDbTable: !Ref StreamingDynamoDbTable
                 SourceObject: !Sub "${BootstrapPrefix}/src-v0.21.6.zip"
                 CustomResourceCodeObject: !Sub "${BootstrapPrefix}/custom-resources-v0.21.6.zip"
                 InitiateChatLambdaCodeObject: !Sub "${BootstrapPrefix}/initiate-chat-lambda-v0.21.6.zip"


### PR DESCRIPTION

*Description of changes:*
 - adds StreamingWebSocketEndpoint and StreamingDynamoDbTable as optional CF parameters to override existing ones that are created when AllowStreamingResponses is True

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
