### PR TITLE
Update node versions, fix dependency issue & make prompting for name optional

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -1009,7 +1009,7 @@ export default {
 
   requestLiveChat(context) {
     console.info('requestLiveChat');
-    if (!context.getters.liveChatUserName()) {
+    if (!context.getters.liveChatUserName() && context.state.config.connect.promptForNameMessage.length > 0) {
       context.commit('setLiveChatStatus', liveChatStatus.REQUEST_USERNAME);
       context.commit(
         'pushMessage',

--- a/src/lex-web-ui-loader/js/defaults/dependencies.js
+++ b/src/lex-web-ui-loader/js/defaults/dependencies.js
@@ -21,10 +21,6 @@
 export const dependenciesFullPage = {
   script: [
     {
-      name: 'Loader',
-      url: './initiate-loader.js',
-    },
-    {
       name: 'Vue',
       url: './3.5.13_dist_vue.global.prod.js',
       canUseMin: false,

--- a/templates/cognito.yaml
+++ b/templates/cognito.yaml
@@ -417,7 +417,7 @@ Resources:
     Condition: ShouldAllowSignUpEmailDomain
     Properties:
       Handler: index.handler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Timeout: 3
       Environment:
         Variables:

--- a/templates/restapi.yaml
+++ b/templates/restapi.yaml
@@ -67,7 +67,7 @@ Resources:
         Description:  AWS Lambda Function to initiate the chat with the end user
         Handler: "index.handler"
         Role: !GetAtt InitiateChatLambdaExecutionRole.Arn
-        Runtime: "nodejs18.x"
+        Runtime: "nodejs22.x"
         MemorySize: 128
         Timeout: 30
         Environment:

--- a/templates/streaming-support.yaml
+++ b/templates/streaming-support.yaml
@@ -63,7 +63,7 @@ Resources:
       Description:  AWS Lambda Function to initiate web socket connection for streaming
       Handler: "index.handler"
       Role: !GetAtt StreamingLambdaExecutionRole.Arn
-      Runtime: "nodejs18.x"
+      Runtime: "nodejs22.x"
       MemorySize: 128
       Timeout: 30
       Environment:


### PR DESCRIPTION
- Update node version to v22 to handle EoL of Lambda support for v18
- The promptForNameMessage will now be skipped if the message is empty
- The initiate-loader.js file being a dependency was causing some issues with fullpage loader scripts in cross origin situations and has been removed. If you need to use this file please refer to it directly in your parent page.