### PR TITLE
End a live chat should the browser window or tab be closed without first having closed the live chat manually

### DIFF
--- a/lex-web-ui/src/components/LexWeb.vue
+++ b/lex-web-ui/src/components/LexWeb.vue
@@ -157,7 +157,7 @@ export default {
     if (!this.isMobile) {
       document.documentElement.style.overflowY = 'hidden';
     }
-    
+
     this.initConfig()
       .then(() => Promise.all([
         this.$store.dispatch(
@@ -192,7 +192,7 @@ export default {
         if (!poolId) {
           return Promise.reject(new Error('no cognito.poolId found in config'))
         }
-        
+
         if (!this.$lexWebUi.awsConfig.credentials) {
           this.$lexWebUi.awsConfig.credentials = this.$store.dispatch('getCredentials', this.$store.state.config).then((creds) => {
             return creds;
@@ -273,6 +273,7 @@ export default {
     }
     this.onResize();
     window.addEventListener('resize', this.onResize, { passive: true });
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
   },
   methods: {
     onResize() {
@@ -347,6 +348,13 @@ export default {
     handleRequestLiveChat() {
       console.info('handleRequestLiveChat');
       this.$store.dispatch('requestLiveChat');
+    },
+    handleBeforeUnload() {
+      console.info('handleBeforeUnload'); //state.chatMode === chatMode.LIVECHAT
+      if (this.$store.state.chatMode === 'livechat') {
+        console.info('disconnecting from livechat');
+        this.handleEndLiveChat();
+      }
     },
     handleEndLiveChat() {
       console.info('LexWeb: handleEndLiveChat');
@@ -573,6 +581,6 @@ NOTE: not using var() for different heights due to IE11 compatibility
   background: transparent;
 }
 
-html { font-size: 14px !important; } 
+html { font-size: 14px !important; }
 
 </style>


### PR DESCRIPTION
End a live chat should the browser window or tab be closed without first having closed the live chat manually

*Issue #, if available:*

*Description of changes:*

add logic to handle the beforeunload event and call method to end live chat if in the correct state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
