### PR TITLE
Set session attributes for previous question and answer

### DIFF
--- a/lex-web-ui/src/store/actions.js
+++ b/lex-web-ui/src/store/actions.js
@@ -572,6 +572,14 @@ export default {
       .then((response) => {
         if (context.state.chatMode === chatMode.BOT &&
           context.state.liveChat.status != liveChatStatus.REQUEST_USERNAME) {
+          context.dispatch('setSessionAttribute', {
+            key: 'previousUtterance',
+            value: message.text
+          });
+          context.dispatch('setSessionAttribute', {
+            key: 'previousLexResponse',
+            value: response.message
+          });
           // check for an array of messages
           if (response.sessionState || (response.message && response.message.includes('{"messages":'))) {
             if (response.message && response.message.includes('{"messages":')) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modified postTextMessage action to assign previous question and answer as Lex session attributes so that they can be easily referenced by the parent page via iFrame loader event based API (onUpdateLexState) as well as on the destination side. QnABot deployments can then reference these attributes on utterances like "thumbs up"/"thumbs down" to like feedback ratings to the appropriate question-answer pair.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
