### PR TITLE
Set text input character limit

### DIFF
--- a/lex-web-ui/src/components/InputContainer.vue
+++ b/lex-web-ui/src/components/InputContainer.vue
@@ -18,6 +18,7 @@
         ref="textInput"
         id="text-input"
         name="text-input"
+        maxlength="1024"
         hide-details
         density="compact"
         variant="underlined"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hard sets the character limit for the text input box element to 1024, which is the maximum character length supported by the RecognizeText API method:
https://docs.aws.amazon.com/lexv2/latest/APIReference/API_runtime_RecognizeText.html
<img width="672" height="232" alt="image" src="https://github.com/user-attachments/assets/058e0910-016b-4c49-bfb0-c4a6db82d7a1" />
This prevents the user from typing more than is permitted and resulting in an error being returned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
